### PR TITLE
Fix the compile method declaration compatibility

### DIFF
--- a/lib/Less/Node/Mixin/Definition.php
+++ b/lib/Less/Node/Mixin/Definition.php
@@ -138,7 +138,7 @@ class Less_Tree_Mixin_Definition extends Less_Tree_Ruleset{
 	}
 
 	// less.js : /lib/less/tree/mixin.js : tree.mixin.Definition.eval
-	public function compile($env, $args, $important) {
+	public function compile($env, $args = NULL, $important = NULL) {
 		$_arguments = array();
 
 		$mixinFrames = array_merge($this->frames, $env->frames);


### PR DESCRIPTION
Fix the runtime notice : `Declaration of Less_Tree_Mixin_Definition::compile() should be compatible with Less_Tree_Ruleset::compile($env) in .../vendor/oyejorge/less.php/lib/Less/Node/Mixin/Definition.php line 222`
