### PR TITLE
Added a way to disable relative urls processing by library

### DIFF
--- a/lib/Less/Environment.php
+++ b/lib/Less/Environment.php
@@ -72,6 +72,9 @@ class Less_Environment{
 		if( isset($options['strictUnits']) ){
 			$this->strictUnits = (bool)$options['strictUnits'];
 		}
+		if( isset($options['relativeUrls']) ){
+			$this->relativeUrls = (bool)$options['relativeUrls'];
+		}
 
 
 		if( self::$compress ){

--- a/lib/Less/Tree/Url.php
+++ b/lib/Less/Tree/Url.php
@@ -27,7 +27,11 @@ class Less_Tree_Url extends Less_Tree{
 		$val = $this->value->compile($ctx);
 
 		// Add the base path if the URL is relative
-		if( $this->currentFileInfo && is_string($val->value) && Less_Environment::isPathRelative($val->value) ){
+		if($ctx->relativeUrls
+			&& $this->currentFileInfo
+			&& is_string($val->value)
+			&& Less_Environment::isPathRelative($val->value)
+		){
 			$rootpath = $this->currentFileInfo['uri_root'];
 			if ( !$val->quote ){
 				$rootpath = preg_replace('/[\(\)\'"\s]/', '\\$1', $rootpath );


### PR DESCRIPTION
Trouble:
Current implementation doesn't allow disable relative urls processing by library as well as method Less_Environment::isPathRelative($val->value) that verifies url is to strict and doesn't provide an ability to use custom absolute url notation.

Solution:
A way to disable relative url processing (see option - "whether to adjust URL's to be relative") has been added.
