### PR TITLE
Add more compatibility to lessc.inc.php

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -167,7 +167,6 @@ class lessc
 
 		$parser = new Less_Parser();
 		$parser->SetImportDirs($this->getImportDirs());
-		$parser->SetOption('compress', true);
 		if( count( $this->registeredVars ) ) $parser->ModifyVars( $this->registeredVars );
 		$parser->parseFile($fname);
 		$out = $parser->getCss();


### PR DESCRIPTION
Enable a working version of setVariables and modify the constructor definition. I am working to replace the compiler for the wp-less wordpress plugin that currently uses lessphp.
