### PR TITLE
Add custom cache method using callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,15 @@ $css = $parser->getCss();
 
 You can specify the caching technique used by changing the ```cache_method``` option. Supported methods are:
 * ```php```: Creates valid PHP files which can be included without any changes (default method).
-* ```var_export```: Like "php", but using PHPs ```var_export()``` function without any optimizations. It's recommended to use "php" instead.
+* ```var_export```: Like "php", but using PHPs ```var_export()``` function without any optimizations.
+  It's recommended to use "php" instead.
 * ```serialize```: Faster, but pretty memory-intense.
-* ```callback```: Use custom callback functions to implement your own caching method. Give the "cache_callback" option with the following syntax:
-  ```array('get' => /* callback */, 'set' => /* callback */)```. "callback" must be callable (see PHPs ```call_user_func()``` and ```is_callable()``` functions).
-  less.php will pass the parser object (class ```Less_Parser```), the path to the parsed .less file ("/some/path/to/file.less") and an identifier that will
-  change every time the .less file is modified. The ```get``` callback must return the ruleset (an array with ```Less_Tree``` objects) provided as fourth
-  parameter of the ```set``` callback. If something goes wrong, return ```NULL``` (cache doesn't exist) or ```FALSE```.
+* ```callback```: Use custom callback functions to implement your own caching method. Give the "cache_callback_get" and
+  "cache_callback_set" options with callables (see PHPs ```call_user_func()``` and ```is_callable()``` functions). less.php
+  will pass the parser object (class ```Less_Parser```), the path to the parsed .less file ("/some/path/to/file.less") and
+  an identifier that will change every time the .less file is modified. The ```get``` callback must return the ruleset
+  (an array with ```Less_Tree``` objects) provided as fourth parameter of the ```set``` callback. If something goes wrong,
+  return ```NULL``` (cache doesn't exist) or ```FALSE```.
   
 
 

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -27,7 +27,8 @@ class Less_Parser{
 		'import_callback'		=> null,
 		'cache_dir'				=> null,
 		'cache_method'			=> 'php', 			// false, 'serialize', 'php', 'var_export', 'callback';
-		'cache_callback'		=> array('get' => null, 'set' => null),
+		'cache_callback_get'	=> null,
+		'cache_callback_set'	=> null,
 
 		'sourceMap'				=> false,			// whether to output a source map
 		'sourceMapBasepath'		=> null,
@@ -449,9 +450,9 @@ class Less_Parser{
 		$cache_file = $this->CacheFile( $file_path );
 		if( $cache_file ){
 			if( Less_Parser::$options['cache_method'] == 'callback' ){
-				if( isset(Less_Parser::$options['cache_callback']['get']) && is_callable(Less_Parser::$options['cache_callback']['get']) ){
+				if( is_callable(Less_Parser::$options['cache_callback_get']) ){
 					$cache = call_user_func_array(
-						Less_Parser::$options['cache_callback']['get'],
+						Less_Parser::$options['cache_callback_get'],
 						array($this, $file_path, $cache_file)
 					);
 
@@ -497,9 +498,9 @@ class Less_Parser{
 		//save the cache
 		if( $cache_file ){
 			if( Less_Parser::$options['cache_method'] == 'callback' ){
-				if( isset(Less_Parser::$options['cache_callback']['set']) && is_callable(Less_Parser::$options['cache_callback']['set']) ){
+				if( is_callable(Less_Parser::$options['cache_callback_set']) ){
 					call_user_func_array(
-						Less_Parser::$options['cache_callback']['set'], 
+						Less_Parser::$options['cache_callback_set'], 
 						array($this, $file_path, $cache_file, $rules)
 					);
 				}


### PR DESCRIPTION
My framework has its own caching method with much more powerful techniques (like different caching methods (Memcached vs. file-based vs. database-based vs. something custom) depending on the cached data - and much more...), so I don't want less.php to create any files on its own. Less.php should use the provided cache method. Rather than implementing 100 different caching methods, simply add an powerful custom cache method using callbacks.

``` php
require_once(ZSIM_DIR.'3rdParty/less.php/Less.php');
$this->compiler = new \Less_Parser(array(
    'cache_method' => 'callback',
    'cache_callback' => array(
        'get' => 'getSingleLessFileCache',
        'set' => 'setSingleLessFileCache'
    )
));

/* ... */

function getSingleLessFileCache(\Less_Parser $compiler, $filePath, $cacheIdentifier) {
    /* do something */
    return $ruleset;
}

function setSingleLessFileCache(\Less_Parser $compiler, $filePath, $cacheIdentifier, $ruleset) {
    /* do something */
}
```
