### PR TITLE
Add support for arbitrary cache filename prefix

### DIFF
--- a/lib/Less/Cache.php
+++ b/lib/Less/Cache.php
@@ -66,7 +66,6 @@ class Less_Cache{
 
 		// generate name for compiled css file
 		$hash = md5(json_encode($less_files));
-		$prefix = $parser_options['cache_prefix'];
  		$list_file = Less_Cache::$cache_dir.Less_Cache::$cache_prefix.$hash.'.list';
 
 


### PR DESCRIPTION
This is an easy patch to allow using a prefix other than the currently hard-coded "lessphp_" when creating a cached CSS file in the given cache directory.
