### PR TITLE
Fix: Import Less files even if they do not have the .less extension

### DIFF
--- a/lib/Less/Tree/Import.php
+++ b/lib/Less/Tree/Import.php
@@ -238,6 +238,10 @@ class Less_Tree_Import extends Less_Tree{
 						$full_path = Less_Environment::normalizePath($path);
 						$uri = Less_Environment::normalizePath(dirname($rooturi.$evald_path));
 						return array( $full_path, $uri );
+					} elseif( file_exists($path.'.less') ){
+						$full_path = Less_Environment::normalizePath($path.'.less');
+						$uri = Less_Environment::normalizePath(dirname($rooturi.$evald_path.'.less'));
+						return array( $full_path, $uri );
 					}
 				}
 			}


### PR DESCRIPTION
@import directives should work even if the .less file extension is not present.

see http://lesscss.org/features/#import-directives-feature-file-extensions:
"If it does not have an extension, .less will be appended and it will be included as a imported Less file."