### PR TITLE
Fix: Forward registered functions to mixin conditions

### DIFF
--- a/lib/Less/Tree/Mixin/Definition.php
+++ b/lib/Less/Tree/Mixin/Definition.php
@@ -199,6 +199,8 @@ class Less_Tree_Mixin_Definition extends Less_Tree_Ruleset{
 				, $env->frames		// the current environment frames
 			);
 
+		$compile_env->functions = $env->functions;
+
 		return (bool)$this->condition->compile($compile_env);
 	}
 


### PR DESCRIPTION
Registered functions need to be forwarded to mixin conditions, else they will not be available for "while" statements.