### PR TITLE
Allow use of non-standard paths

### DIFF
--- a/lib/Less/Environment.php
+++ b/lib/Less/Environment.php
@@ -110,6 +110,10 @@ class Less_Environment{
 	public static function isPathRelative($path){
 		return !preg_match('/^(?:[a-z-]+:|\/)/',$path);
 	}
+	
+	public static function isValidPath($path){
+	        return preg_match('#^(\w+/){1,2}\w+\.\w+$#',$path);
+	}
 
 
 	/**

--- a/lib/Less/Tree/Url.php
+++ b/lib/Less/Tree/Url.php
@@ -45,6 +45,7 @@ class Less_Tree_Url extends Less_Tree{
 				&& $this->currentFileInfo
 				&& is_string($val->value)
 				&& Less_Environment::isPathRelative($val->value)
+				&& Less_Environment::isValidRelative($val->value)
 			){
 				$rootpath = $this->currentFileInfo['uri_root'];
 				if ( !$val->quote ){


### PR DESCRIPTION
This is a real world example:

background: url('{{ asset.url "theme::fonts/flags/standard/us.svg" }}');

The URL was being prefixed with "flags/":

background: url('flags/THE_CORRECT_RESULT');

This type of non-valid path should be left alone. If it is invalid and unintentional, the developer will correct it. Otherwise it might be something like the above parser for PyroCMS v3.

This will come up when using Larvel and frameworks like it as well that use blade / twig.