### PR TITLE
Fix permanent change of environment when parser fails

### DIFF
--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -173,38 +173,49 @@ class Less_Parser{
 		@ini_set('precision',16);
 		$locale = setlocale(LC_NUMERIC, 0);
 		setlocale(LC_NUMERIC, "C");
+		
+		try {
 
- 		$root = new Less_Tree_Ruleset(array(), $this->rules );
-		$root->root = true;
-		$root->firstRoot = true;
-
-
-		$this->PreVisitors($root);
-
-		self::$has_extends = false;
-		$evaldRoot = $root->compile($this->env);
-
-
-
-		$this->PostVisitors($evaldRoot);
-
-		if( Less_Parser::$options['sourceMap'] ){
-			$generator = new Less_SourceMap_Generator($evaldRoot, Less_Parser::$contentsMap, Less_Parser::$options );
-			// will also save file
-			// FIXME: should happen somewhere else?
-			$css = $generator->generateCSS();
-		}else{
-			$css = $evaldRoot->toCSS();
-		}
-
-		if( Less_Parser::$options['compress'] ){
-			$css = preg_replace('/(^(\s)+)|((\s)+$)/', '', $css);
-		}
+	 		$root = new Less_Tree_Ruleset(array(), $this->rules );
+			$root->root = true;
+			$root->firstRoot = true;
+	
+	
+			$this->PreVisitors($root);
+	
+			self::$has_extends = false;
+			$evaldRoot = $root->compile($this->env);
+	
+	
+	
+			$this->PostVisitors($evaldRoot);
+	
+			if( Less_Parser::$options['sourceMap'] ){
+				$generator = new Less_SourceMap_Generator($evaldRoot, Less_Parser::$contentsMap, Less_Parser::$options );
+				// will also save file
+				// FIXME: should happen somewhere else?
+				$css = $generator->generateCSS();
+			}else{
+				$css = $evaldRoot->toCSS();
+			}
+	
+			if( Less_Parser::$options['compress'] ){
+				$css = preg_replace('/(^(\s)+)|((\s)+$)/', '', $css);
+			}
+		
+		} catch (Exception $exc) {
+        	   // Intentional fall-through so we can reset environment
+        	}
 
 		//reset php settings
 		@ini_set('precision',$precision);
 		setlocale(LC_NUMERIC, $locale);
-
+		
+		// Rethrow exception after we handled resetting the environment
+		if (!empty($exc)) {
+            		throw $exc;
+        	}
+        
 		return $css;
 	}
 


### PR DESCRIPTION
I noticed some strange floating point errors that occured due to the failure of the parser. The original precision I was depending on was 14 and with 16 my unit test failed. After some digging this was the best solution I could think of when we don't have try/catch/finally

(btw, to reproduce I had used a variable that was undefined)