### PR TITLE
Avoid empty rootpath

### DIFF
--- a/lib/Less/Tree/Import.php
+++ b/lib/Less/Tree/Import.php
@@ -231,7 +231,7 @@ class Less_Tree_Import extends Less_Tree{
 						$full_path = $path;
 						return array( $full_path, $uri );
 					}
-				}else{
+				}elseif( !empty($rootpath) ){
 					$path = rtrim($rootpath,'/\\').'/'.ltrim($evald_path,'/\\');
 
 					if( file_exists($path) ){


### PR DESCRIPTION
This causes problems on Windows with open basedir restrictions. When the $rootpath is empty and the $evald_path something `../style.less` for example, it will try to open `/../style.less` which is absolute and outside allowed paths (thus file_exists calls fail).
This check avoids empty rootpaths.

(But there might be better ways to fix this)