### PR TITLE
Throw meaningful errors when encountering invalid color statements

### DIFF
--- a/lib/Less/Functions.php
+++ b/lib/Less/Functions.php
@@ -17,7 +17,6 @@ class Less_Functions{
 		$this->currentFileInfo = $currentFileInfo;
 	}
 
-
 	/**
 	 * @param string $op
 	 */
@@ -66,11 +65,14 @@ class Less_Functions{
 		}
 	}
 
-	public function rgb ($r, $g, $b){
+	public function rgb ($r = null, $g = null, $b = null){
+		if (is_null($r) || is_null($g) || is_null($b)) {
+			throw new Less_Exception_Compiler("rgb expects three parameters");
+		}
 		return $this->rgba($r, $g, $b, 1.0);
 	}
 
-	public function rgba($r, $g, $b, $a){
+	public function rgba($r = null, $g = null, $b = null, $a = null){
 		$rgb = array($r, $g, $b);
 		$rgb = array_map(array('Less_Functions','scaled'),$rgb);
 
@@ -144,133 +146,129 @@ class Less_Functions{
 						 $a);
 	}
 
-	public function hue($color){
-
-		if( $color instanceof Less_Tree_Color ){
-			$c = $color->toHSL();
-			return new Less_Tree_Dimension(Less_Parser::round($c['h']));
+	public function hue($color = null){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to hue must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$c = $color->toHSL();
+		return new Less_Tree_Dimension(Less_Parser::round($c['h']));
 	}
 
-	public function saturation($color){
-
-		if( $color instanceof Less_Tree_Color ){
-			$c = $color->toHSL();
-			return new Less_Tree_Dimension(Less_Parser::round($c['s'] * 100), '%');
+	public function saturation($color = null){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to saturation must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$c = $color->toHSL();
+		return new Less_Tree_Dimension(Less_Parser::round($c['s'] * 100), '%');
 	}
 
-	public function lightness($color){
-
-		if( $color instanceof Less_Tree_Color ){
-			$c = $color->toHSL();
-			return new Less_Tree_Dimension(Less_Parser::round($c['l'] * 100), '%');
+	public function lightness($color = null){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to lightness must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$c = $color->toHSL();
+		return new Less_Tree_Dimension(Less_Parser::round($c['l'] * 100), '%');
 	}
 
-	public function hsvhue( $color ){
-
-		if( $color instanceof Less_Tree_Color ){
-			$hsv = $color->toHSV();
-			return new Less_Tree_Dimension( Less_Parser::round($hsv['h']) );
+	public function hsvhue( $color = null ){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to hsvhue must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$hsv = $color->toHSV();
+		return new Less_Tree_Dimension( Less_Parser::round($hsv['h']) );
 	}
 
 
-	public function hsvsaturation( $color ){
-
-		if( $color instanceof Less_Tree_Color ){
-			$hsv = $color->toHSV();
-			return new Less_Tree_Dimension( Less_Parser::round($hsv['s'] * 100), '%' );
+	public function hsvsaturation( $color = null ){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to hsvsaturation must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$hsv = $color->toHSV();
+		return new Less_Tree_Dimension( Less_Parser::round($hsv['s'] * 100), '%' );
 	}
 
-	public function hsvvalue( $color ){
-
-		if( $color instanceof Less_Tree_Color ){
-			$hsv = $color->toHSV();
-			return new Less_Tree_Dimension( Less_Parser::round($hsv['v'] * 100), '%' );
+	public function hsvvalue( $color = null ){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to hsvvalue must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$hsv = $color->toHSV();
+		return new Less_Tree_Dimension( Less_Parser::round($hsv['v'] * 100), '%' );
 	}
 
-	public function red($color) {
-
-		if( $color instanceof Less_Tree_Color ){
-			return new Less_Tree_Dimension( $color->rgb[0] );
+	public function red($color = null) {
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to red must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		return new Less_Tree_Dimension( $color->rgb[0] );
 	}
 
-	public function green($color) {
-
-		if( $color instanceof Less_Tree_Color ){
-			return new Less_Tree_Dimension( $color->rgb[1] );
+	public function green($color = null) {
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to green must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		return new Less_Tree_Dimension( $color->rgb[1] );
 	}
 
-	public function blue($color) {
-
-		if( $color instanceof Less_Tree_Color ){
-			return new Less_Tree_Dimension( $color->rgb[2] );
+	public function blue($color = null) {
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to blue must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		return new Less_Tree_Dimension( $color->rgb[2] );
 	}
 
-	public function alpha($color){
-
-		if( $color instanceof Less_Tree_Color ){
-			$c = $color->toHSL();
-			return new Less_Tree_Dimension($c['a']);
+	public function alpha($color = null){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to alpha must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$c = $color->toHSL();
+		return new Less_Tree_Dimension($c['a']);
 	}
 
-	public function luma ($color) {
-
-		if( $color instanceof Less_Tree_Color ){
-			return new Less_Tree_Dimension(Less_Parser::round( $color->luma() * $color->alpha * 100), '%');
+	public function luma ($color = null) {
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to luma must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		return new Less_Tree_Dimension(Less_Parser::round( $color->luma() * $color->alpha * 100), '%');
 	}
 
-	public function luminance( $color ){
-
-		if( $color instanceof Less_Tree_Color ){
-			$luminance =
-				(0.2126 * $color->rgb[0] / 255)
-			  + (0.7152 * $color->rgb[1] / 255)
-			  + (0.0722 * $color->rgb[2] / 255);
-
-			return new Less_Tree_Dimension(Less_Parser::round( $luminance * $color->alpha * 100), '%');
+	public function luminance( $color = null ){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to luminance must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$luminance =
+			(0.2126 * $color->rgb[0] / 255)
+		  + (0.7152 * $color->rgb[1] / 255)
+		  + (0.0722 * $color->rgb[2] / 255);
+
+		return new Less_Tree_Dimension(Less_Parser::round( $luminance * $color->alpha * 100), '%');
 	}
 
-	public function saturate($color, $amount = null){
+	public function saturate($color = null, $amount = null){
 		// filter: saturate(3.2);
 		// should be kept as is, so check for color
-		if( !property_exists($color,'rgb') ){
+		if ($color instanceof Less_Tree_Dimension) {
 			return null;
 		}
+
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to saturate must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+			throw new Less_Exception_Compiler('The second argument to saturate must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+
 		$hsl = $color->toHSL();
 
 		$hsl['s'] += $amount->value / 100;
@@ -282,100 +280,114 @@ class Less_Functions{
 	/**
 	 * @param Less_Tree_Dimension $amount
 	 */
-	public function desaturate($color, $amount){
-
-		if( $color instanceof Less_Tree_Color ){
-			$hsl = $color->toHSL();
-
-			$hsl['s'] -= $amount->value / 100;
-			$hsl['s'] = self::clamp($hsl['s']);
-
-			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+	public function desaturate($color = null, $amount = null){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to desaturate must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+			throw new Less_Exception_Compiler('The second argument to desaturate must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$hsl = $color->toHSL();
+
+		$hsl['s'] -= $amount->value / 100;
+		$hsl['s'] = self::clamp($hsl['s']);
+
+		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
 	}
 
 
 
-	public function lighten($color, $amount){
-
-		if( $color instanceof Less_Tree_Color ){
-			$hsl = $color->toHSL();
-
-			$hsl['l'] += $amount->value / 100;
-			$hsl['l'] = self::clamp($hsl['l']);
-
-			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+	public function lighten($color = null, $amount=null){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to lighten must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+			throw new Less_Exception_Compiler('The second argument to lighten must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$hsl = $color->toHSL();
+
+		$hsl['l'] += $amount->value / 100;
+		$hsl['l'] = self::clamp($hsl['l']);
+
+		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
 	}
 
-	public function darken($color, $amount){
-
-		if( $color instanceof Less_Tree_Color ){
-			$hsl = $color->toHSL();
-			$hsl['l'] -= $amount->value / 100;
-			$hsl['l'] = self::clamp($hsl['l']);
-
-			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+	public function darken($color = null, $amount = null){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to darken must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+			throw new Less_Exception_Compiler('The second argument to darken must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$hsl = $color->toHSL();
+		$hsl['l'] -= $amount->value / 100;
+		$hsl['l'] = self::clamp($hsl['l']);
+
+		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
 	}
 
-	public function fadein($color, $amount){
-
-		if( $color instanceof Less_Tree_Color ){
-			$hsl = $color->toHSL();
-			$hsl['a'] += $amount->value / 100;
-			$hsl['a'] = self::clamp($hsl['a']);
-			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+	public function fadein($color = null, $amount = null){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to fadein must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+			throw new Less_Exception_Compiler('The second argument to fadein must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$hsl = $color->toHSL();
+		$hsl['a'] += $amount->value / 100;
+		$hsl['a'] = self::clamp($hsl['a']);
+		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
 	}
 
-	public function fadeout($color, $amount){
-
-		if( $color instanceof Less_Tree_Color ){
-			$hsl = $color->toHSL();
-			$hsl['a'] -= $amount->value / 100;
-			$hsl['a'] = self::clamp($hsl['a']);
-			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+	public function fadeout($color = null, $amount = null){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to fadeout must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+			throw new Less_Exception_Compiler('The second argument to fadeout must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$hsl = $color->toHSL();
+		$hsl['a'] -= $amount->value / 100;
+		$hsl['a'] = self::clamp($hsl['a']);
+		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
 	}
 
-	public function fade($color, $amount){
-
-		if( $color instanceof Less_Tree_Color ){
-			$hsl = $color->toHSL();
-
-			$hsl['a'] = $amount->value / 100;
-			$hsl['a'] = self::clamp($hsl['a']);
-			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+	public function fade($color = null, $amount = null){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to fade must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+			throw new Less_Exception_Compiler('The second argument to fade must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$hsl = $color->toHSL();
+
+		$hsl['a'] = $amount->value / 100;
+		$hsl['a'] = self::clamp($hsl['a']);
+		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
 	}
 
 
 
-	public function spin($color, $amount){
-
-		if( $color instanceof Less_Tree_Color ){
-			$hsl = $color->toHSL();
-			$hue = fmod($hsl['h'] + $amount->value, 360);
-
-			$hsl['h'] = $hue < 0 ? 360 + $hue : $hue;
-
-			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+	public function spin($color = null, $amount = null){
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to spin must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('')) {
+			throw new Less_Exception_Compiler('The second argument to spin must be a number' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
-		Less_Functions::Expected('color',$color);
+		$hsl = $color->toHSL();
+		$hue = fmod($hsl['h'] + $amount->value, 360);
+
+		$hsl['h'] = $hue < 0 ? 360 + $hue : $hue;
+
+		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
 	}
 
 	//
@@ -386,46 +398,47 @@ class Less_Functions{
 	/**
 	 * @param Less_Tree_Color $color1
 	 */
-	public function mix($color1, $color2, $weight = null){
+	public function mix($color1 = null, $color2 = null, $weight = null){
+		if (!$color1 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to mix must be a color' . ($color1 instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$color2 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The second argument to mix must be a color' . ($color2 instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
 		if (!$weight) {
 			$weight = new Less_Tree_Dimension('50', '%');
 		}
-
-		if( !$color1 instanceof Less_Tree_Color ) {
-			Less_Functions::Expected('color',$color);
+		if (!$weight instanceof Less_Tree_Dimension || !$weight->unit->is('%')) {
+			throw new Less_Exception_Compiler('The third argument to contrast must be a percentage' . ($weight instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
-		elseif( !$color2 instanceof Less_Tree_Color ) {
-			Less_Functions::Expected('color',$color);
-		}
-		else {
-			$p = $weight->value / 100.0;
-			$w = $p * 2 - 1;
-			$hsl1 = $color1->toHSL();
-			$hsl2 = $color2->toHSL();
-			$a = $hsl1['a'] - $hsl2['a'];
 
-			$w1 = (((($w * $a) == -1) ? $w : ($w + $a) / (1 + $w * $a)) + 1) / 2;
-			$w2 = 1 - $w1;
+		$p = $weight->value / 100.0;
+		$w = $p * 2 - 1;
+		$hsl1 = $color1->toHSL();
+		$hsl2 = $color2->toHSL();
+		$a = $hsl1['a'] - $hsl2['a'];
 
-			$rgb = array($color1->rgb[0] * $w1 + $color2->rgb[0] * $w2,
-						 $color1->rgb[1] * $w1 + $color2->rgb[1] * $w2,
-						 $color1->rgb[2] * $w1 + $color2->rgb[2] * $w2);
+		$w1 = (((($w * $a) == -1) ? $w : ($w + $a) / (1 + $w * $a)) + 1) / 2;
+		$w2 = 1 - $w1;
 
-			$alpha = $color1->alpha * $p + $color2->alpha * (1 - $p);
+		$rgb = array($color1->rgb[0] * $w1 + $color2->rgb[0] * $w2,
+					 $color1->rgb[1] * $w1 + $color2->rgb[1] * $w2,
+					 $color1->rgb[2] * $w1 + $color2->rgb[2] * $w2);
 
-			return new Less_Tree_Color($rgb, $alpha);
-		}
+		$alpha = $color1->alpha * $p + $color2->alpha * (1 - $p);
+
+		return new Less_Tree_Color($rgb, $alpha);
 	}
 
 	public function greyscale($color){
-		return $this->desaturate($color, new Less_Tree_Dimension(100));
+		return $this->desaturate($color, new Less_Tree_Dimension(100,'%'));
 	}
 
 
 	public function contrast( $color, $dark = null, $light = null, $threshold = null){
 		// filter: contrast(3.2);
 		// should be kept as is, so check for color
-		if( !property_exists($color,'rgb') ){
+		if (!$color instanceof Less_Tree_Color) {
 			return null;
 		}
 		if( !$light ){
@@ -434,6 +447,14 @@ class Less_Functions{
 		if( !$dark ){
 			$dark = $this->rgba(0, 0, 0, 1.0);
 		}
+
+		if (!$dark instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The second argument to contrast must be a color' . ($dark instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$light instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The third argument to contrast must be a color' . ($light instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+
 		//Figure out which is actually light and dark!
 		if( $dark->luma() > $light->luma() ){
 			$t = $light;
@@ -717,6 +738,10 @@ class Less_Functions{
 	}
 
 	public function argb($color) {
+		if (!$color instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to argb must be a color' . ($dark instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+
 		return new Less_Tree_Anonymous($color->toARGB());
 	}
 
@@ -974,21 +999,6 @@ class Less_Functions{
 
 
 	/**
-	 * @param string $type
-	 */
-	private static function Expected( $type, $arg ){
-
-		$debug = debug_backtrace();
-		array_shift($debug);
-		$last = array_shift($debug);
-		$last = array_intersect_key($last,array('function'=>'','class'=>'','line'=>''));
-
-		$message = 'Object of type '.get_class($arg).' passed to darken function. Expecting `'.$type.'`. '.$arg->toCSS().'. '.print_r($last,true);
-		throw new Less_Exception_Compiler($message);
-
-	}
-
-	/**
 	 * Php version of javascript's `encodeURIComponent` function
 	 *
 	 * @param string $string The string to encode
@@ -1022,7 +1032,14 @@ class Less_Functions{
 		return new Less_Tree_Color($r, $ar);
 	}
 
-	public function multiply($color1, $color2 ){
+	public function multiply($color1 = null, $color2 = null ){
+		if (!$color1 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to multiply must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$color2 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The second argument to multiply must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+
 		return $this->colorBlend( array($this,'colorBlendMultiply'),  $color1, $color2 );
 	}
 
@@ -1030,7 +1047,14 @@ class Less_Functions{
 		return $cb * $cs;
 	}
 
-	public function screen($color1, $color2 ){
+	public function screen($color1 = null, $color2 = null ){
+		if (!$color1 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to screen must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$color2 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The second argument to screen must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+
 		return $this->colorBlend( array($this,'colorBlendScreen'),  $color1, $color2 );
 	}
 
@@ -1038,7 +1062,14 @@ class Less_Functions{
 		return $cb + $cs - $cb * $cs;
 	}
 
-	public function overlay($color1, $color2){
+	public function overlay($color1 = null, $color2 = null){
+		if (!$color1 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to overlay must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$color2 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The second argument to overlay must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+
 		return $this->colorBlend( array($this,'colorBlendOverlay'),  $color1, $color2 );
 	}
 
@@ -1049,7 +1080,14 @@ class Less_Functions{
 			: $this->colorBlendScreen($cb - 1, $cs);
 	}
 
-	public function softlight($color1, $color2){
+	public function softlight($color1 = null, $color2 = null){
+		if (!$color1 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to softlight must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$color2 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The second argument to softlight must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+
 		return $this->colorBlend( array($this,'colorBlendSoftlight'),  $color1, $color2 );
 	}
 
@@ -1064,7 +1102,14 @@ class Less_Functions{
 		return $cb - (1 - 2 * $cs) * $e * ($d - $cb);
 	}
 
-	public function hardlight($color1, $color2){
+	public function hardlight($color1 = null, $color2 = null){
+		if (!$color1 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to hardlight must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$color2 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The second argument to hardlight must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+
 		return $this->colorBlend( array($this,'colorBlendHardlight'),  $color1, $color2 );
 	}
 
@@ -1072,7 +1117,14 @@ class Less_Functions{
 		return $this->colorBlendOverlay($cs, $cb);
 	}
 
-	public function difference($color1, $color2) {
+	public function difference($color1 = null, $color2 = null) {
+		if (!$color1 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to difference must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$color2 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The second argument to difference must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+
 		return $this->colorBlend( array($this,'colorBlendDifference'),  $color1, $color2 );
 	}
 
@@ -1080,7 +1132,14 @@ class Less_Functions{
 		return abs($cb - $cs);
 	}
 
-	public function exclusion( $color1, $color2 ){
+	public function exclusion( $color1 = null, $color2 = null ){
+		if (!$color1 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to exclusion must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$color2 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The second argument to exclusion must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+
 		return $this->colorBlend( array($this,'colorBlendExclusion'),  $color1, $color2 );
 	}
 
@@ -1088,7 +1147,14 @@ class Less_Functions{
 		return $cb + $cs - 2 * $cb * $cs;
 	}
 
-	public function average($color1, $color2){
+	public function average($color1 = null, $color2 = null){
+		if (!$color1 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to average must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$color2 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The second argument to average must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+
 		return $this->colorBlend( array($this,'colorBlendAverage'),  $color1, $color2 );
 	}
 
@@ -1097,7 +1163,14 @@ class Less_Functions{
 		return ($cb + $cs) / 2;
 	}
 
-	public function negation($color1, $color2 ){
+	public function negation($color1 = null, $color2 = null ){
+		if (!$color1 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The first argument to negation must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+		if (!$color2 instanceof Less_Tree_Color) {
+			throw new Less_Exception_Compiler('The second argument to negation must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
+		}
+
 		return $this->colorBlend( array($this,'colorBlendNegation'),  $color1, $color2 );
 	}
 

--- a/lib/Less/Functions.php
+++ b/lib/Less/Functions.php
@@ -265,7 +265,7 @@ class Less_Functions{
 		if (!$color instanceof Less_Tree_Color) {
 			throw new Less_Exception_Compiler('The first argument to saturate must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
-		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+		if (!$amount instanceof Less_Tree_Dimension) {
 			throw new Less_Exception_Compiler('The second argument to saturate must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
@@ -284,7 +284,7 @@ class Less_Functions{
 		if (!$color instanceof Less_Tree_Color) {
 			throw new Less_Exception_Compiler('The first argument to desaturate must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
-		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+		if (!$amount instanceof Less_Tree_Dimension) {
 			throw new Less_Exception_Compiler('The second argument to desaturate must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
@@ -302,7 +302,7 @@ class Less_Functions{
 		if (!$color instanceof Less_Tree_Color) {
 			throw new Less_Exception_Compiler('The first argument to lighten must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
-		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+		if (!$amount instanceof Less_Tree_Dimension) {
 			throw new Less_Exception_Compiler('The second argument to lighten must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
@@ -318,7 +318,7 @@ class Less_Functions{
 		if (!$color instanceof Less_Tree_Color) {
 			throw new Less_Exception_Compiler('The first argument to darken must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
-		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+		if (!$amount instanceof Less_Tree_Dimension) {
 			throw new Less_Exception_Compiler('The second argument to darken must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
@@ -333,7 +333,7 @@ class Less_Functions{
 		if (!$color instanceof Less_Tree_Color) {
 			throw new Less_Exception_Compiler('The first argument to fadein must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
-		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+		if (!$amount instanceof Less_Tree_Dimension) {
 			throw new Less_Exception_Compiler('The second argument to fadein must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
@@ -347,7 +347,7 @@ class Less_Functions{
 		if (!$color instanceof Less_Tree_Color) {
 			throw new Less_Exception_Compiler('The first argument to fadeout must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
-		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+		if (!$amount instanceof Less_Tree_Dimension) {
 			throw new Less_Exception_Compiler('The second argument to fadeout must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
@@ -361,7 +361,7 @@ class Less_Functions{
 		if (!$color instanceof Less_Tree_Color) {
 			throw new Less_Exception_Compiler('The first argument to fade must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
-		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('%')) {
+		if (!$amount instanceof Less_Tree_Dimension) {
 			throw new Less_Exception_Compiler('The second argument to fade must be a percentage' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
@@ -378,7 +378,7 @@ class Less_Functions{
 		if (!$color instanceof Less_Tree_Color) {
 			throw new Less_Exception_Compiler('The first argument to spin must be a color' . ($color instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
-		if (!$amount instanceof Less_Tree_Dimension || !$amount->unit->is('')) {
+		if (!$amount instanceof Less_Tree_Dimension) {
 			throw new Less_Exception_Compiler('The second argument to spin must be a number' . ($amount instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 
@@ -408,7 +408,7 @@ class Less_Functions{
 		if (!$weight) {
 			$weight = new Less_Tree_Dimension('50', '%');
 		}
-		if (!$weight instanceof Less_Tree_Dimension || !$weight->unit->is('%')) {
+		if (!$weight instanceof Less_Tree_Dimension) {
 			throw new Less_Exception_Compiler('The third argument to contrast must be a percentage' . ($weight instanceof Less_Tree_Expression ? ' (did you forgot commas?)' : '') );
 		}
 

--- a/lib/Less/Functions.php
+++ b/lib/Less/Functions.php
@@ -145,101 +145,176 @@ class Less_Functions{
 	}
 
 	public function hue($color){
-		$c = $color->toHSL();
-		return new Less_Tree_Dimension(Less_Parser::round($c['h']));
+
+		if( $color instanceof Less_Tree_Color ){
+			$c = $color->toHSL();
+			return new Less_Tree_Dimension(Less_Parser::round($c['h']));
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function saturation($color){
-		$c = $color->toHSL();
-		return new Less_Tree_Dimension(Less_Parser::round($c['s'] * 100), '%');
+
+		if( $color instanceof Less_Tree_Color ){
+			$c = $color->toHSL();
+			return new Less_Tree_Dimension(Less_Parser::round($c['s'] * 100), '%');
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function lightness($color){
-		$c = $color->toHSL();
-		return new Less_Tree_Dimension(Less_Parser::round($c['l'] * 100), '%');
+
+		if( $color instanceof Less_Tree_Color ){
+			$c = $color->toHSL();
+			return new Less_Tree_Dimension(Less_Parser::round($c['l'] * 100), '%');
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function hsvhue( $color ){
-		$hsv = $color->toHSV();
-		return new Less_Tree_Dimension( Less_Parser::round($hsv['h']) );
+
+		if( $color instanceof Less_Tree_Color ){
+			$hsv = $color->toHSV();
+			return new Less_Tree_Dimension( Less_Parser::round($hsv['h']) );
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 
 	public function hsvsaturation( $color ){
-		$hsv = $color->toHSV();
-		return new Less_Tree_Dimension( Less_Parser::round($hsv['s'] * 100), '%' );
+
+		if( $color instanceof Less_Tree_Color ){
+			$hsv = $color->toHSV();
+			return new Less_Tree_Dimension( Less_Parser::round($hsv['s'] * 100), '%' );
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function hsvvalue( $color ){
-		$hsv = $color->toHSV();
-		return new Less_Tree_Dimension( Less_Parser::round($hsv['v'] * 100), '%' );
+
+		if( $color instanceof Less_Tree_Color ){
+			$hsv = $color->toHSV();
+			return new Less_Tree_Dimension( Less_Parser::round($hsv['v'] * 100), '%' );
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function red($color) {
-		return new Less_Tree_Dimension( $color->rgb[0] );
+
+		if( $color instanceof Less_Tree_Color ){
+			return new Less_Tree_Dimension( $color->rgb[0] );
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function green($color) {
-		return new Less_Tree_Dimension( $color->rgb[1] );
+
+		if( $color instanceof Less_Tree_Color ){
+			return new Less_Tree_Dimension( $color->rgb[1] );
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function blue($color) {
-		return new Less_Tree_Dimension( $color->rgb[2] );
+
+		if( $color instanceof Less_Tree_Color ){
+			return new Less_Tree_Dimension( $color->rgb[2] );
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function alpha($color){
-		$c = $color->toHSL();
-		return new Less_Tree_Dimension($c['a']);
+
+		if( $color instanceof Less_Tree_Color ){
+			$c = $color->toHSL();
+			return new Less_Tree_Dimension($c['a']);
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function luma ($color) {
-		return new Less_Tree_Dimension(Less_Parser::round( $color->luma() * $color->alpha * 100), '%');
+
+		if( $color instanceof Less_Tree_Color ){
+			return new Less_Tree_Dimension(Less_Parser::round( $color->luma() * $color->alpha * 100), '%');
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function luminance( $color ){
-		$luminance =
-			(0.2126 * $color->rgb[0] / 255)
-		  + (0.7152 * $color->rgb[1] / 255)
-		  + (0.0722 * $color->rgb[2] / 255);
 
-		return new Less_Tree_Dimension(Less_Parser::round( $luminance * $color->alpha * 100), '%');
+		if( $color instanceof Less_Tree_Color ){
+			$luminance =
+				(0.2126 * $color->rgb[0] / 255)
+			  + (0.7152 * $color->rgb[1] / 255)
+			  + (0.0722 * $color->rgb[2] / 255);
+
+			return new Less_Tree_Dimension(Less_Parser::round( $luminance * $color->alpha * 100), '%');
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function saturate($color, $amount = null){
-		// filter: saturate(3.2);
-		// should be kept as is, so check for color
-		if( !property_exists($color,'rgb') ){
-			return null;
+
+		if( $color instanceof Less_Tree_Color ){
+			// filter: saturate(3.2);
+			// should be kept as is, so check for color
+			if( !property_exists($color,'rgb') ){
+				return null;
+			}
+			$hsl = $color->toHSL();
+
+			$hsl['s'] += $amount->value / 100;
+			$hsl['s'] = self::clamp($hsl['s']);
+
+			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
 		}
-		$hsl = $color->toHSL();
 
-		$hsl['s'] += $amount->value / 100;
-		$hsl['s'] = self::clamp($hsl['s']);
-
-		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+		Less_Functions::Expected('color',$color);
 	}
 
 	/**
 	 * @param Less_Tree_Dimension $amount
 	 */
 	public function desaturate($color, $amount){
-		$hsl = $color->toHSL();
 
-		$hsl['s'] -= $amount->value / 100;
-		$hsl['s'] = self::clamp($hsl['s']);
+		if( $color instanceof Less_Tree_Color ){
+			$hsl = $color->toHSL();
 
-		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+			$hsl['s'] -= $amount->value / 100;
+			$hsl['s'] = self::clamp($hsl['s']);
+
+			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 
 
 	public function lighten($color, $amount){
-		$hsl = $color->toHSL();
 
-		$hsl['l'] += $amount->value / 100;
-		$hsl['l'] = self::clamp($hsl['l']);
+		if( $color instanceof Less_Tree_Color ){
+			$hsl = $color->toHSL();
 
-		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+			$hsl['l'] += $amount->value / 100;
+			$hsl['l'] = self::clamp($hsl['l']);
+
+			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function darken($color, $amount){
@@ -256,36 +331,56 @@ class Less_Functions{
 	}
 
 	public function fadein($color, $amount){
-		$hsl = $color->toHSL();
-		$hsl['a'] += $amount->value / 100;
-		$hsl['a'] = self::clamp($hsl['a']);
-		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+
+		if( $color instanceof Less_Tree_Color ){
+			$hsl = $color->toHSL();
+			$hsl['a'] += $amount->value / 100;
+			$hsl['a'] = self::clamp($hsl['a']);
+			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function fadeout($color, $amount){
-		$hsl = $color->toHSL();
-		$hsl['a'] -= $amount->value / 100;
-		$hsl['a'] = self::clamp($hsl['a']);
-		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+
+		if( $color instanceof Less_Tree_Color ){
+			$hsl = $color->toHSL();
+			$hsl['a'] -= $amount->value / 100;
+			$hsl['a'] = self::clamp($hsl['a']);
+			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	public function fade($color, $amount){
-		$hsl = $color->toHSL();
 
-		$hsl['a'] = $amount->value / 100;
-		$hsl['a'] = self::clamp($hsl['a']);
-		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+		if( $color instanceof Less_Tree_Color ){
+			$hsl = $color->toHSL();
+
+			$hsl['a'] = $amount->value / 100;
+			$hsl['a'] = self::clamp($hsl['a']);
+			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 
 
 	public function spin($color, $amount){
-		$hsl = $color->toHSL();
-		$hue = fmod($hsl['h'] + $amount->value, 360);
 
-		$hsl['h'] = $hue < 0 ? 360 + $hue : $hue;
+		if( $color instanceof Less_Tree_Color ){
+			$hsl = $color->toHSL();
+			$hue = fmod($hsl['h'] + $amount->value, 360);
 
-		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+			$hsl['h'] = $hue < 0 ? 360 + $hue : $hue;
+
+			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+		}
+
+		Less_Functions::Expected('color',$color);
 	}
 
 	//
@@ -301,22 +396,30 @@ class Less_Functions{
 			$weight = new Less_Tree_Dimension('50', '%');
 		}
 
-		$p = $weight->value / 100.0;
-		$w = $p * 2 - 1;
-		$hsl1 = $color1->toHSL();
-		$hsl2 = $color2->toHSL();
-		$a = $hsl1['a'] - $hsl2['a'];
+		if( !$color1 instanceof Less_Tree_Color ) {
+			Less_Functions::Expected('color',$color);
+		}
+		elseif( !$color2 instanceof Less_Tree_Color ) {
+			Less_Functions::Expected('color',$color);
+		}
+		else {
+			$p = $weight->value / 100.0;
+			$w = $p * 2 - 1;
+			$hsl1 = $color1->toHSL();
+			$hsl2 = $color2->toHSL();
+			$a = $hsl1['a'] - $hsl2['a'];
 
-		$w1 = (((($w * $a) == -1) ? $w : ($w + $a) / (1 + $w * $a)) + 1) / 2;
-		$w2 = 1 - $w1;
+			$w1 = (((($w * $a) == -1) ? $w : ($w + $a) / (1 + $w * $a)) + 1) / 2;
+			$w2 = 1 - $w1;
 
-		$rgb = array($color1->rgb[0] * $w1 + $color2->rgb[0] * $w2,
-					 $color1->rgb[1] * $w1 + $color2->rgb[1] * $w2,
-					 $color1->rgb[2] * $w1 + $color2->rgb[2] * $w2);
+			$rgb = array($color1->rgb[0] * $w1 + $color2->rgb[0] * $w2,
+						 $color1->rgb[1] * $w1 + $color2->rgb[1] * $w2,
+						 $color1->rgb[2] * $w1 + $color2->rgb[2] * $w2);
 
-		$alpha = $color1->alpha * $p + $color2->alpha * (1 - $p);
+			$alpha = $color1->alpha * $p + $color2->alpha * (1 - $p);
 
-		return new Less_Tree_Color($rgb, $alpha);
+			return new Less_Tree_Color($rgb, $alpha);
+		}
 	}
 
 	public function greyscale($color){

--- a/lib/Less/Functions.php
+++ b/lib/Less/Functions.php
@@ -266,22 +266,17 @@ class Less_Functions{
 	}
 
 	public function saturate($color, $amount = null){
-
-		if( $color instanceof Less_Tree_Color ){
-			// filter: saturate(3.2);
-			// should be kept as is, so check for color
-			if( !property_exists($color,'rgb') ){
-				return null;
-			}
-			$hsl = $color->toHSL();
-
-			$hsl['s'] += $amount->value / 100;
-			$hsl['s'] = self::clamp($hsl['s']);
-
-			return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
+		// filter: saturate(3.2);
+		// should be kept as is, so check for color
+		if( !property_exists($color,'rgb') ){
+			return null;
 		}
+		$hsl = $color->toHSL();
 
-		Less_Functions::Expected('color',$color);
+		$hsl['s'] += $amount->value / 100;
+		$hsl['s'] = self::clamp($hsl['s']);
+
+		return $this->hsla($hsl['h'], $hsl['s'], $hsl['l'], $hsl['a']);
 	}
 
 	/**

--- a/test/Fixtures/bug-reports/css/210.css
+++ b/test/Fixtures/bug-reports/css/210.css
@@ -1,0 +1,120 @@
+
+body .color-channels {
+  --hue: 210;
+  --saturation: 50%;
+  --lightness: 40%;
+  --hsvhue: 210;
+  --hsvsaturation: 67%;
+  --hsvvalue: 60%;
+  --red: 51;
+  --green: 102;
+  --blue: 153;
+  --alpha: 0.9;
+  --luma: 11%;
+  --luminance: 33%;
+}
+body .color-definitions .rgb {
+  color: #336699;
+}
+body .color-definitions .rgba {
+  color: rgba(51, 102, 153, 0.9);
+}
+body .color-definitions .argb {
+  color: #e6336699;
+}
+body .color-definitions .hsl {
+  color: #336699;
+}
+body .color-definitions .hsla {
+  color: rgba(51, 102, 153, 0.9);
+}
+body .color-definitions .hsv {
+  color: #326699;
+}
+body .color-definitions .hsva {
+  color: rgba(50, 102, 153, 0.9);
+}
+body .css-filters .saturate {
+  color: saturate(200%);
+}
+body .color-operations .saturate {
+  color: rgba(0, 102, 204, 0.9);
+}
+body .color-operations .desaturate {
+  color: rgba(102, 102, 102, 0.9);
+}
+body .color-operations .lighten {
+  color: rgba(217, 230, 242, 0.9);
+}
+body .color-operations .darken {
+  color: rgba(0, 0, 0, 0.9);
+}
+body .color-operations .fadein {
+  color: #336699;
+}
+body .color-operations .fadeout {
+  color: rgba(51, 102, 153, 0.4);
+}
+body .color-operations .fade {
+  color: rgba(51, 102, 153, 0.5);
+}
+body .color-operations .spin50 {
+  color: rgba(85, 51, 153, 0.9);
+}
+body .color-operations .spin720 {
+  color: rgba(51, 102, 153, 0.9);
+}
+body .color-operations .spin-50 {
+  color: rgba(51, 153, 119, 0.9);
+}
+body .color-operations .spin-720 {
+  color: rgba(51, 102, 153, 0.9);
+}
+body .color-operations .mix-default {
+  color: rgba(128, 102, 77, 0.9);
+}
+body .color-operations .mix60 {
+  color: rgba(112, 102, 92, 0.9);
+}
+body .color-operations .greyscale {
+  color: rgba(102, 102, 102, 0.9);
+}
+body .color-operations .contrast-1param {
+  color: #ffffff;
+}
+body .color-operations .contrast-2param {
+  color: #ffffff;
+}
+body .color-operations .contrast-3param {
+  color: rgba(252, 179, 208, 0.9);
+}
+body .color-operations .contrast-4param {
+  color: rgba(252, 179, 208, 0.9);
+}
+body .color-blenders .multiply {
+  color: rgba(57, 52, 14, 0.99);
+}
+body .color-blenders .screen {
+  color: rgba(198, 152, 139, 0.99);
+}
+body .color-blenders .overlay {
+  color: rgba(90, 85, 56, 0.99);
+}
+body .color-blenders .softlight {
+  color: rgba(96, 92, 89, 0.99);
+}
+body .color-blenders .hardlight {
+  color: rgba(165, 85, 14, 0.99);
+}
+body .color-blenders .difference {
+  color: rgba(148, 19, 139, 0.99);
+}
+body .color-blenders .exclusion {
+  color: rgba(165, 119, 139, 0.99);
+}
+body .color-blenders .average {
+  color: rgba(128, 102, 77, 0.99);
+}
+body .color-blenders .negation {
+  color: rgba(232, 185, 139, 0.99);
+}

--- a/test/Fixtures/bug-reports/less/210.less
+++ b/test/Fixtures/bug-reports/less/210.less
@@ -1,0 +1,153 @@
+@color1: rgba(51, 102, 153, 0.9);
+@color2: rgba(204, 102, 0, 0.9);
+@color3: rgba(252, 179, 208, 0.9);
+
+/* color channel functions */
+@h: hue(@color1);
+@s: saturation(@color1);
+@l: lightness(@color1);
+@hsvh: hsvhue(@color1);
+@hsvs: hsvsaturation(@color1);
+@hsvv: hsvvalue(@color1);
+@r: red(@color1);
+@g: green(@color1);
+@b: blue(@color1);
+@a: alpha(@color1);
+@luma: luma(@color1);
+@luminance: luminance(@color1);
+
+body {
+
+	.color-channels {
+		--hue: @h;
+		--saturation: @s;
+		--lightness: @l;
+		--hsvhue: @hsvh;
+		--hsvsaturation: @hsvs;
+		--hsvvalue: @hsvv;
+		--red: @r;
+		--green: @g;
+		--blue: @b;
+		--alpha: @a;
+		--luma: @luma;
+		--luminance: @luminance;
+	}
+
+	.color-definitions {
+		.rgb {
+			color: rgb(@r,@g,@b);
+		}
+		.rgba {
+			color: rgba(@r,@g,@b,@a);
+		}
+		.argb {
+			color: argb(rgba(@r,@g,@b,@a));
+		}
+		.hsl {
+			color: hsl(@h,@s,@l);
+		}
+		.hsla {
+			color: hsla(@h,@s,@l,@a);
+		}
+		.hsv {
+			color: hsv(@hsvh,@hsvs,@hsvv);
+		}
+		.hsva {
+			color: hsva(@hsvh,@hsvs,@hsvv,@a);
+		}
+	}
+
+	.css-filters {
+		.saturate {
+			color: saturate(200%);
+		}
+	}
+
+	.color-operations {
+		.saturate {
+			color: saturate(@color1,50%);
+		}
+		.desaturate {
+			color: desaturate(@color1,50%);
+		}
+		.lighten {
+			color: lighten(@color1,50%);
+		}
+		.darken {
+			color: darken(@color1,50%);
+		}
+		.fadein {
+			color: fadein(@color1,50%);
+		}
+		.fadeout {
+			color: fadeout(@color1,50%);
+		}
+		.fade {
+			color: fade(@color1,50%);
+		}
+		.spin50 {
+			color: spin(@color1,50);
+		}
+		.spin720 {
+			color: spin(@color1,720);
+		}
+		.spin-50 {
+			color: spin(@color1,-50);
+		}
+		.spin-720 {
+			color: spin(@color1,-720);
+		}
+		.mix-default {
+			color: mix(@color1,@color2);
+		}
+		.mix60 {
+			color: mix(@color1,@color2,60%);
+		}
+		.greyscale {
+			color: greyscale(@color1);
+		}
+		.contrast-1param {
+			color: contrast(@color1);
+		}
+		.contrast-2param {
+			color: contrast(@color1,@color2);
+		}
+		.contrast-3param {
+			color: contrast(@color1,@color2,@color3);
+		}
+		.contrast-4param {
+			color: contrast(@color1,@color2,@color3,75%);
+		}
+	}
+
+	.color-blenders {
+		.multiply {
+			color: multiply(@color1,@color2);
+		}
+		.screen {
+			color: screen(@color1,@color2);
+		}
+		.overlay {
+			color: overlay(@color1,@color2);
+		}
+		.softlight {
+			color: softlight(@color1,@color2);
+		}
+		.hardlight {
+			color: hardlight(@color1,@color2);
+		}
+		.difference {
+			color: difference(@color1,@color2);
+		}
+		.exclusion {
+			color: exclusion(@color1,@color2);
+		}
+		.average {
+			color: average(@color1,@color2);
+		}
+		.negation {
+			color: negation(@color1,@color2);
+		}
+	}
+
+}


### PR DESCRIPTION
Applied the color validation check from Less_Functions::darken to all of the other color modification methods in Less_Functions, making it much easier to debug invalid LESS color statements (Less.php now throws errors on invalid color statements, giving you clues as to what went wrong, instead of just crashing).

Side note:
Personally I would have written it as if (!$color instanceof Less_Tree_color) { } instead of placing each of the methods' entire code inside an if statement, but since darken was already done that way I figured it might be the chosen coding style. Feel free to change if desired.