### PR TITLE
Add .gitattributes to exclude /test directory when installing via Composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-test/	export-ignore
+test/ export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 test/ export-ignore
+.travis.yml export-ignore
+phpunit.xml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/	export-ignore


### PR DESCRIPTION
When installed `less.php` via Composer package first time in my Wordpress theme framework — I'm found that Theme Check plugin noticed me for some errors:

* WARNING: Found `ini_set` in the file index.php. Themes should not change server PHP settings.
`Line 6: @ini_set('display_errors',1);`
* WARNING: Found `ini_set` in the file Parser.php. Themes should not change server PHP settings.
`Line 153: @ini_set('precision',16);`
`Line 186: @ini_set('precision',$precision);`

In order to exclude `/test` directory from installing via Composer I’m tried [solution](http://stackoverflow.com/a/15460972/1510732) with adding `.gitattributes` file with `test/ export-ignore` .

All works fine and package installed via Composer without /test directory in it.

**Important note**: `.gitattributes` must be added to stable tagged version of `less.php` package.
In order that solution works for me now, i'm created temporary stable version [1.7.0.4](https://github.com/vburlak/less.php/tree/v1.7.0.4) in my fork of less.php

My `composer.json`:

```
{
	"repositories": [
    {
        "type": "vcs",
        "url": "https://github.com/vburlak/less.php"
    }
	],
    "require": {
		"oyejorge/less.php": "~1.7"
    }
}
```
