### PR TITLE
SourceMap source path improvments

### DIFF
--- a/lib/Less/SourceMap/Generator.php
+++ b/lib/Less/SourceMap/Generator.php
@@ -91,13 +91,9 @@ class Less_SourceMap_Generator extends Less_Configurable {
 		$this->encoder = new Less_SourceMap_Base64VLQ();
 
 		$this->SetOptions($options);
-
-
-		// fix windows paths
-		if( !empty($this->options['sourceMapRootpath']) ){
-			$this->options['sourceMapRootpath'] = str_replace('\\', '/', $this->options['sourceMapRootpath']);
-			$this->options['sourceMapRootpath'] = rtrim($this->options['sourceMapRootpath'],'/').'/';
-		}
+		
+		$this->options['sourceMapRootpath'] = $this->fixWindowsPath($this->options['sourceMapRootpath'], true);
+		$this->options['sourceMapBasepath'] = $this->fixWindowsPath($this->options['sourceMapBasepath'], true);
 	}
 
 	/**
@@ -167,7 +163,8 @@ class Less_SourceMap_Generator extends Less_Configurable {
 	 */
 	protected function normalizeFilename($filename){
 
-		$filename = str_replace('\\', '/', $filename);
+		$filename = $this->fixWindowsPath($filename);
+
 		$rootpath = $this->getOption('sourceMapRootpath');
 		$basePath = $this->getOption('sourceMapBasepath');
 
@@ -348,6 +345,21 @@ class Less_SourceMap_Generator extends Less_Configurable {
 	 */
 	protected function findFileIndex($filename){
 		return $this->source_keys[$filename];
+	}
+
+	/**
+	 * fix windows paths
+	 * @param  string $path
+	 * @return string      
+	 */
+	public function fixWindowsPath($path, $addEndSlash = false){
+		$slash = ($addEndSlash) ? '/' : '';
+		if( !empty($path) ){
+			$path = str_replace('\\', '/', $path);
+			$path = rtrim($path,'/') . $slash;
+		}
+
+		return $path;
 	}
 
 }


### PR DESCRIPTION
Fixes source path In Windows. 
and small improvments.
Test in this config:
```php
$options       = array(
	'cache_dir'         => 'less_cache', 
	'compress'          => true, 
	'sourceMap'         => true,
    'sourceMapWriteTo'  => __DIR__ . '/css/stlyles.map',
    'sourceMapURL'      => '/css/stlyles.map',
    'sourceRoot'        => '/', // 'http://site.com/' or '/'
    // 'sourceMapRootpath' => '/', // 'http://site.com/' or '/'
    'sourceMapBasepath' => __DIR__ ,
);
```
output
http://joxi.ru/8238b6vsp9WwAO