### PR TITLE
Double slash in path

### DIFF
--- a/lib/Less/Cache.php
+++ b/lib/Less/Cache.php
@@ -252,7 +252,7 @@ class Less_Cache{
 					continue;
 				}
 
-				$full_path = Less_Cache::$cache_dir.'/'.$file;
+				$full_path = Less_Cache::$cache_dir . $file;
 
 				// make sure the file still exists
 				// css files may have already been deleted
@@ -280,7 +280,7 @@ class Less_Cache{
 				if( $type === 'list' ){
 					self::ListFiles($full_path, $list, $css_file_name);
 					if( $css_file_name ){
-						$css_file = Less_Cache::$cache_dir.'/'.$css_file_name;
+						$css_file = Less_Cache::$cache_dir . $css_file_name;
 						if( file_exists($css_file) ){
 							unlink($css_file);
 						}


### PR DESCRIPTION
Line 216 already append a trailing slash to Less_Cache::$cache_dir so there is no need to add another one between it and the file when you're building a full path or a file

Line 216
`Less_Cache::$cache_dir = rtrim(Less_Cache::$cache_dir,'/').'/';`