### PR TITLE
increase visibility for Less_Parser#$rules

### DIFF
--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -53,7 +53,7 @@ class Less_Parser{
 	 */
 	private $env;
 
-	private $rules = array();
+	protected $rules = array();
 
 	private static $imports = array();
 


### PR DESCRIPTION
@oyejorge our usecase was (as explained in the commit message) that we needed access to the parser rules - which isn't possible right now and i don't see a reason why it can't be? it doesn't need to be public though, but with a `private` property we are pretty much lost.

if you don't like to change the visibility itself, what about adding a method to get those rules back? that would be feasible as well.