### PR TITLE
Modify variables after parser has parsed the buffer

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -67,11 +67,11 @@ class lessc{
 
 		$parser = new Less_Parser($this->getOptions());
 		$parser->setImportDirs($this->getImportDirs());
-		if( count( $this->registeredVars ) ) $parser->ModifyVars( $this->registeredVars );
 		foreach ($this->libFunctions as $name => $func) {
 			$parser->registerFunction($name, $func);
 		}
 		$parser->parse($buffer);
+		if( count( $this->registeredVars ) ) $parser->ModifyVars( $this->registeredVars );
 
 		return $parser->getCss();
 	}


### PR DESCRIPTION
Currently, the registered variables serve no purpose, other than possibly setting variables that would otherwise cause the compile to crash because they are undeclared in the source.  Calling ModifyVars after the parser has parsed the buffer gives precedence to registered variables over variables in the source files, a more expected behavior and probable use case for registering variables in the first place.