### PR TITLE
Making relative URL behavior correctly disabled by default.

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -5,7 +5,7 @@ require_once dirname(__FILE__) . '/../lib/Less/Autoloader.php';
 Less_Autoloader::register();
 
 // Create our environment
-$env		= array('compress' => false);
+$env		= array('compress' => false, 'relativeUrls' => false);
 $silent		= false;
 $watch		= false;
 $rootpath	= '';


### PR DESCRIPTION
I doubt many people use the command line compiler as most are using the Symfony 2 package only, but I ran into this: the "relative URLs" behavior defaults to true inside the parser, and the command line interface only allows the option to be set as true, meaning that it is impossible to turn it off.

This simple change just restores the default intended command line behavior. The use as a Symfony compiler is unchanged, since the actual parser still defaults to true. (In fact, the only way to change this is to extend the `lessc` class and provide a new implementation of `lessc::getOptions()`.)