### PR TITLE
Escape variables in Less_Parser::serializeVars() using tilda and quotes

### DIFF
--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -2469,7 +2469,8 @@ class Less_Parser{
 		$s = '';
 
 		foreach($vars as $name => $value){
-			$s .= (($name[0] === '@') ? '' : '@') . $name .': '. $value . ((substr($value,-1) === ';') ? '' : ';');
+			$value = trim($value);
+			$s .= (($name[0] === '@') ? '' : '@') . $name .': ~"'. $value . '"' . ((substr($value,-1) === ';') ? '' : ';');
 		}
 
 		return $s;

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -2469,8 +2469,11 @@ class Less_Parser{
 		$s = '';
 
 		foreach($vars as $name => $value){
-			$value = trim($value);
-			$s .= (($name[0] === '@') ? '' : '@') . $name .': ~"'. $value . '"' . ((substr($value,-1) === ';') ? '' : ';');
+			// If there is ':' in the value, escape it, using tilda and quotes
+	            	if ( strpos($value, ':') !== false ) {
+        	        	$value = '~"' . str_replace('\\', '\\\\', trim($value)) . '"';
+                	}
+			$s .= (($name[0] === '@') ? '' : '@') . $name .': '. $value . ((substr($value,-1) === ';') ? '' : ';');
 		}
 
 		return $s;


### PR DESCRIPTION
Escape variables in Less_Parser::serializeVars() using tilda and quotes.

In my case this was breaking the compilation:

```php
$parser->ModifyVars(array('__CSS_URL__' => 'http://www.example.com/css/'));
```

translates into:

```less
@__CSS_URL__: http://www.example.com/css/;
```