### PR TITLE
respect this->options in getOptions

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -23,6 +23,7 @@ class lessc{
 	protected $libFunctions = array();
 	protected $registeredVars = array();
 	private $formatterName;
+	private $options = array();
 
 	public function __construct($lessc=null, $sourceName=null) {}
 

--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -94,6 +94,10 @@ class lessc{
 				$options['compress'] = true;
 				break;
 		}
+		if (is_array($this->options))
+		{
+			$options = array_merge($options, $this->options);
+		}
 		return $options;
 	}
 


### PR DESCRIPTION
I wondered why there's a method
```
private function setOption($name, $value){
$this->options[$name] = $value;
}
```
but these options are ignored in method getOptions where e.g. *relativeUrls* is hardcoded with value false. https://github.com/oyejorge/less.php/blob/master/lessc.inc.php#L90-L98

Thus
```
$less = new lessc;
$less->setOption('relativeUrls', true);
```
doesn't work.