### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
 		}
 	],
 	"require": {
-		"PHP" : ">=5.3",
+		"PHP" : ">=5.3"
+	},
+	"require-dev": {
 		"phpunit/phpunit": "~4.8.16"
 	},
 	"scripts": {


### PR DESCRIPTION
phpunit should not be required as part of the standard package, only as part of the development package. Packages downstream using yours shouldn't be forced to include phpunit in their releases. composer automatically includes `require-dev` when updating locally so this shouldn't affect you, but `dev` can be disabled when building packages like so `composer.phar install --prefer-dist --no-dev`