### PR TITLE
don't use set_time_limit when running cli

### DIFF
--- a/test/index.php
+++ b/test/index.php
@@ -8,7 +8,9 @@ error_reporting(E_ALL | E_STRICT); //previous to php 5.4, E_ALL did not include 
 error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR);
 set_error_handler(array('ParserTest','showError'),E_ALL | E_STRICT);
 
-set_time_limit(60);
+if (php_sapi_name() != "cli") {
+    set_time_limit(60);
+}
 //error_reporting(E_ALL | E_STRICT);
 
 $dir = dirname(dirname(__FILE__));

--- a/test/tracefile-analyser.php
+++ b/test/tracefile-analyser.php
@@ -5,7 +5,9 @@
 $fileName = '/tmp/trace.2043925204.xt';
 $sortKey  = 'time-own'; //array( 'calls','time-inclusive' , 'memory-inclusive', 'time-own', 'memory-own','time-own-percall' )
 $elements = 50;
-set_time_limit(120);
+if (php_sapi_name() != "cli") {
+    set_time_limit(120);
+}
 echo '<pre>';
 
 $o = new drXdebugTraceFileParser( $fileName );


### PR DESCRIPTION
When these scripts are included in some cli app, they could cause time
limit issues while we generally could not care about how long a script
takes to run on cli.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>