### PR TITLE
take relative-url into account when building the cache filename

### DIFF
--- a/lib/Less/Cache.php
+++ b/lib/Less/Cache.php
@@ -83,13 +83,12 @@ class Less_Cache{
 		$hash = md5(json_encode($less_files));
  		$list_file = Less_Cache::$cache_dir . Less_Cache::$prefix . $hash . '.list';
 
-
  		// check cached content
  		if( !isset($parser_options['use_cache']) || $parser_options['use_cache'] === true ){
 			if( file_exists($list_file) ){
 
 				self::ListFiles($list_file, $list, $cached_name);
-				$compiled_name = self::CompiledName($list);
+				$compiled_name = self::CompiledName($list, $hash);
 
 				// if $cached_name is the same as the $compiled name, don't regenerate
 				if( !$cached_name || $cached_name === $compiled_name ){
@@ -109,7 +108,7 @@ class Less_Cache{
 			return false;
 		}
 
-		$compiled_name = self::CompiledName( $less_files );
+		$compiled_name = self::CompiledName( $less_files, $hash );
 		$output_file = self::OutputFile($compiled_name, $parser_options );
 
 
@@ -194,7 +193,7 @@ class Less_Cache{
 	}
 
 
-	private static function CompiledName( $files ){
+	private static function CompiledName( $files, $extrahash ){
 
 		//save the file list
 		$temp = array(Less_Version::cache_version);
@@ -202,7 +201,7 @@ class Less_Cache{
 			$temp[] = filemtime($file)."\t".filesize($file)."\t".$file;
 		}
 
-		return Less_Cache::$prefix.sha1(json_encode($temp)).'.css';
+		return Less_Cache::$prefix.sha1(json_encode($temp).$extrahash).'.css';
 	}
 
 


### PR DESCRIPTION
this allows to compile the same file with different relative-urls with caching
in use & tested on https://streaming.media.ccc.de/ (https://github.com/voc/streaming-website/)