### PR TITLE
Fix: @amount should be optional

### DIFF
--- a/lib/Less/Functions.php
+++ b/lib/Less/Functions.php
@@ -813,11 +813,11 @@ class Less_Functions{
 		return is_a($n, $type) ? new Less_Tree_Keyword('true') : new Less_Tree_Keyword('false');
 	}
 
-	public function tint($color, $amount) {
+	public function tint($color, $amount = null) {
 		return $this->mix( $this->rgb(255,255,255), $color, $amount);
 	}
 
-	public function shade($color, $amount) {
+	public function shade($color, $amount = null) {
 		return $this->mix($this->rgb(0, 0, 0), $color, $amount);
 	}
 


### PR DESCRIPTION
The Less.js docs say the following:
"weight: Optional, a percentage balance point between color and black, defaults to 50%."