### PR TITLE
Init after setting options to fix #306

### DIFF
--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -109,13 +109,14 @@ class Less_Parser{
 		self::$contentsMap = array();
 
 		$this->env = new Less_Environment($options);
-		$this->env->Init();
 
 		//set new options
 		if( is_array($options) ){
 			$this->SetOptions(Less_Parser::$default_options);
 			$this->SetOptions($options);
 		}
+		
+		$this->env->Init();
 	}
 
 	/**


### PR DESCRIPTION
The problem was that Less_Environment::Init() is called before options are set but needs them to select which $_outputMap to use by looking at  Less_Parser::$options['compress']. Thus it always selects the non-compressed $_outputMap.