### PR TITLE
Use a dataprovider for tests.

### DIFF
--- a/test/phpunit/FixturesTest.php
+++ b/test/phpunit/FixturesTest.php
@@ -3,19 +3,12 @@
 
 class phpunit_FixturesTest extends phpunit_bootstrap{
 
-
-	/**
-	 * Test the contents of the files in /test/Fixtures/lessjs/expected
-	 *
-	 */
-	function testLessJs(){
-
-		echo "\nBegin Tests";
-
+        public function filelistProvider() {
+                $filelist = array();
 		$css_dir = $this->fixtures_dir.'/lessjs/expected';
 		$files = scandir($css_dir);
 
-		foreach($files as $file){
+                foreach($files as $file){
 			if( $file == '.' || $file == '..' ){
 				continue;
 			}
@@ -25,14 +18,26 @@ class phpunit_FixturesTest extends phpunit_bootstrap{
 			if( is_dir($expected_file) ){
 				continue;
 			}
-
-			$this->CompareFile( $expected_file );
+			$filelist[$file] = array($expected_file);
 		}
-
-		echo "\n";
+		return $filelist;
 	}
 
+	/**
+	 * Test the contents of the files in /test/Fixtures/lessjs/expected without any cache.
+	 *
+         * @dataProvider filelistProvider
+	 */
+	function testLessJsWithoutCache($expected_file){
+		$less_file = $this->TranslateFile( $expected_file );
+		$expected_css = trim(file_get_contents($expected_file));
 
+		$parser = new Less_Parser();
+		$parser->parseFile($less_file);
+		$css = $parser->getCss();
+		$css = trim($css);
+		$this->assertEquals( $expected_css, $css );
+	}
 
 	/**
 	 * Change a css file name to a less file name
@@ -52,48 +57,28 @@ class phpunit_FixturesTest extends phpunit_bootstrap{
 	/**
 	 * Compare the parser results with the expected css
 	 *
+         * @dataProvider filelistProvider
 	 */
-	function CompareFile( $expected_file ){
+	function testLessJsWithCache($expected_file){
 
+		if (!$this->cache_dir) {
+			$this->MarkTestSkipped('No cache folder available');
+		}
 		$less_file = $this->TranslateFile( $expected_file );
 		$expected_css = trim(file_get_contents($expected_file));
 
+		$options = array('cache_dir'=>$this->cache_dir);
+		$files = array( $less_file => '' );
 
-		// Check with standard parser
-		echo "\n  ".basename($expected_file);
-		echo "\n    - Standard Compiler";
-
-		$parser = new Less_Parser();
-		$parser->parseFile($less_file);
-		$css = $parser->getCss();
+		$css_file_name = Less_Cache::Regen( $files, $options );
+		$css = file_get_contents($this->cache_dir.'/'.$css_file_name);
 		$css = trim($css);
-		$this->assertEquals( $expected_css, $css );
+		$this->assertEquals( $expected_css, $css, 'CSS must be equal when generating the cache and producing output');
 
-
-		// Check with cache
-		if( $this->cache_dir ){
-
-			$options = array('cache_dir'=>$this->cache_dir);
-			$files = array( $less_file => '' );
-
-			echo "\n    - Regenerating Cache";
-			$css_file_name = Less_Cache::Regen( $files, $options );
-			$css = file_get_contents($this->cache_dir.'/'.$css_file_name);
-			$css = trim($css);
-			$this->assertEquals( $expected_css, $css );
-
-
-
-			// Check using the cached data
-			echo "\n    - Using Cache";
-			$css_file_name = Less_Cache::Get( $files, $options );
-			$css = file_get_contents($this->cache_dir.'/'.$css_file_name);
-			$css = trim($css);
-			$this->assertEquals( $expected_css, $css );
-
-		}
-
-
+		$css_file_name = Less_Cache::Get( $files, $options );
+		$css = file_get_contents($this->cache_dir.'/'.$css_file_name);
+		$css = trim($css);
+		$this->assertEquals( $expected_css, $css, 'CSS must be equal when constructing it directly from cache');
 	}
 
 

--- a/test/phpunit/FunctionTest.php
+++ b/test/phpunit/FunctionTest.php
@@ -5,8 +5,6 @@ class phpunit_FunctionTest extends phpunit_bootstrap{
 	 * Test
 	 */
 	public function testFunction() {
-		echo "\nBegin Tests";
-
 		$less_file = $this->fixtures_dir.'/functions/less/f1.less';
 		$expected_css = file_get_contents( $this->fixtures_dir.'/functions/css/f1.css' );
 

--- a/test/phpunit/MapTest.php
+++ b/test/phpunit/MapTest.php
@@ -7,8 +7,6 @@ class phpunit_MapTest extends phpunit_bootstrap{
 	 * Test
 	 */
 	public function testMap(){
-		echo "\nBegin Tests";
-
 		$less_file			= $this->fixtures_dir.'/bootstrap3-sourcemap/less/bootstrap.less';
 		$map_file			= $this->fixtures_dir.'/bootstrap3-sourcemap/expected/bootstrap.map';
 		$map_destination	= $this->cache_dir.'/bootstrap.map';

--- a/test/phpunit/bootstrap.php
+++ b/test/phpunit/bootstrap.php
@@ -6,22 +6,18 @@ class phpunit_bootstrap extends PHPUnit_Framework_TestCase{
 	public $fixtures_dir;
 	public $cache_dir;
 
-	function setUp(){
-		echo "\nSet-Up: ".get_class($this);
-
+	public function __construct($name = NULL, array $data = array(), $dataName = '') {
 		$root_directory = dirname(dirname(dirname(__FILE__)));
 
 		require_once( $root_directory . '/lib/Less/Autoloader.php' );
 		Less_Autoloader::register();
 
 		$this->fixtures_dir = $root_directory.'/test/Fixtures';
-		echo "\n  fixtures_dir: ".$this->fixtures_dir;
 
 		$this->cache_dir = $root_directory.'/test/phpunit/_cache/';
 		$this->CheckCacheDirectory();
 
-
-		echo "\n\n";
+		parent::__construct($name, $data, $dataName);
 	}
 
 	/**
@@ -31,16 +27,12 @@ class phpunit_bootstrap extends PHPUnit_Framework_TestCase{
 	function CheckCacheDirectory(){
 
 		if( !file_exists($this->cache_dir) && !mkdir($this->cache_dir) ){
-			echo "\n  cache_dir could not be created:    ".$this->cache_dir;
 			return false;
 		}
 
 		if( !is_writable($this->cache_dir) ){
-			echo "\n  cache_dir not writable:    ".$this->cache_dir;
 			return false;
 		}
-
-		echo "\n  cache_dir:    ".$this->cache_dir;
 	}
 
 }


### PR DESCRIPTION
To use more standardized PHPUnit tests with the output, use
a dataProvider and different tests for each of the less files
to test with.

This will provide a different failure for each file, rather than
stopping the output when a single file fails.