### PR TITLE
Change Less_Tree_Call properties back to public

### DIFF
--- a/lib/Less/Tree/Call.php
+++ b/lib/Less/Tree/Call.php
@@ -10,10 +10,10 @@
 class Less_Tree_Call extends Less_Tree{
     public $value;
 
-    protected $name;
-    protected $args;
-    protected $index;
-    protected $currentFileInfo;
+    public $name;
+    public $args;
+    public $index;
+    public $currentFileInfo;
     public $type = 'Call';
 
 	public function __construct($name, $args, $index, $currentFileInfo = null ){


### PR DESCRIPTION
Prior to c301107622f8065910c025ce69c71e61d18cd901 all these properties were public. [concrete5 relies on this](https://github.com/concrete5/concrete5/blob/44187d3084554d1d704f9fe68ecdc817e9810bc0/concrete/src/StyleCustomizer/Style/ColorStyle.php#L62-L67)