### PR TITLE
Use strpos (much faster than preg_match) to determine if a char is a white space

### DIFF
--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -664,9 +664,15 @@ class Less_Parser{
 		array_pop($this->saveStack);
 	}
 
-
+	/**
+	 * Determine if the character at the specified offset from the current position is a white space.
+	 *
+	 * @param int $offset
+	 *
+	 * @return bool
+	 */
 	private function isWhitespace($offset = 0) {
-		return preg_match('/\s/',$this->input[ $this->pos + $offset]);
+		return strpos(" \t\n\r\v\f", $this->input[$this->pos + $offset]) !== false;
 	}
 
 	/**


### PR DESCRIPTION
What about using `strpos` instead of the slower `preg_match`?

White space characters are [defined by the PCRELib](https://github.com/php/php-src/blob/master/ext/pcre/pcrelib/doc/pcre.txt#L5203-L5204) as:
- LF (dec 10 = hex \x0a = char "\n")
- HT (dec 9 = hex \x09 = char "\t")
- VT (dec 11 = hex \x0b = char "\v")
- FF (dec 12 = hex \x0c = char "\f")
- CR (dec 13 = hex \x0d = char "\r")
- space (dec 32 = hex \x20 = char " ")
