### PR TITLE
Avoid calling realpath on urls

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -150,7 +150,7 @@ class lessc {
 		$oldImport = $this->importDir;
 
 		$this->importDir = (array)$this->importDir;
-		$this->importDir[] = realpath( $pi['dirname'] ).'/';
+		$this->importDir[] = Less_Parser::AbsPath( $pi['dirname'] ).'/';
 
 		$this->allParsedFiles = array();
 		$this->addParsedFile( $fname );
@@ -271,6 +271,6 @@ class lessc {
 	}
 
 	protected function addParsedFile( $file ) {
-		$this->allParsedFiles[realpath( $file )] = filemtime( $file );
+		$this->allParsedFiles[Less_Parser::AbsPath( $file )] = filemtime( $file );
 	}
 }

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -352,7 +352,7 @@ class Less_Parser{
 
 
 		if( $filename ){
-			$filename = self::WinPath(realpath($filename));
+			$filename = self::AbsPath($filename, true);
 		}
 		$uri_root = self::WinPath($uri_root);
 
@@ -2658,6 +2658,18 @@ class Less_Parser{
 
 	public static function WinPath($path){
 		return str_replace('\\', '/', $path);
+	}
+
+	public static function AbsPath($path, $winPath = false){
+		if (preg_match('_^(https?:)?//\\w+(\\.\\w+)+/\\w+_', $path)) {
+			return $winPath ? '' : false;
+		} else {
+			$path = realpath($path);
+			if ($winPath) {
+				$path = self::WinPath($path);
+			}
+			return $path;
+		}
 	}
 
 	public function CacheEnabled(){

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -2661,7 +2661,7 @@ class Less_Parser{
 	}
 
 	public static function AbsPath($path, $winPath = false){
-		if (preg_match('_^(https?:)?//\\w+(\\.\\w+)+/\\w+_', $path)) {
+		if (strpos($path, '//') !== false && preg_match('_^(https?:)?//\\w+(\\.\\w+)+/\\w+_', $path)) {
 			return $winPath ? '' : false;
 		} else {
 			$path = realpath($path);

--- a/lib/Less/Tree/Import.php
+++ b/lib/Less/Tree/Import.php
@@ -289,7 +289,7 @@ class Less_Tree_Import extends Less_Tree{
 	 */
 	private function Skip($path, $env){
 
-		$path = Less_Parser::winPath(realpath($path));
+		$path = Less_Parser::AbsPath($path, true);
 
 		if( $path && Less_Parser::FileParsed($path) ){
 


### PR DESCRIPTION
Calling `realpath` on URLs like `//fonts.googleapis.com/css` takes ages on Windows (in the order of 15/20 seconds): let's avoid that...