### PR TITLE
Fix continue statement within switch/case keeping original behavior

### DIFF
--- a/lib/Less/Exception/Chunk.php
+++ b/lib/Less/Exception/Chunk.php
@@ -67,7 +67,7 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 				case 40:
 					$parenLevel++;
 					$lastParen = $this->parserCurrentIndex;
-					continue;
+					break;
 
 				// )
 				case 41:
@@ -75,18 +75,18 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 					if( $parenLevel < 0 ){
 						return $this->fail("missing opening `(`");
 					}
-					continue;
+					break;
 
 				// ;
 				case 59:
 					//if (!$parenLevel) { $this->emitChunk();	}
-					continue;
+					break;
 
 				// {
 				case 123:
 					$level++;
 					$lastOpening = $this->parserCurrentIndex;
-					continue;
+					break;
 
 				// }
 				case 125:
@@ -96,10 +96,10 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 
 					}
 					//if (!$level && !$parenLevel) { $this->emitChunk(); }
-					continue;
+					break;
 				// \
 				case 92:
-					if ($this->parserCurrentIndex < $this->input_len - 1) { $this->parserCurrentIndex++; continue; }
+					if ($this->parserCurrentIndex < $this->input_len - 1) { $this->parserCurrentIndex++; break; }
 					return $this->fail("unescaped `\\`");
 
 				// ", ' and `
@@ -119,12 +119,12 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 							$this->parserCurrentIndex++;
 						}
 					}
-					if ($matched) { continue; }
+					if ($matched) { break; }
 					return $this->fail("unmatched `" . chr($cc) . "`", $currentChunkStartIndex);
 
 				// /, check for comment
 				case 47:
-					if ($parenLevel || ($this->parserCurrentIndex == $this->input_len - 1)) { continue; }
+					if ($parenLevel || ($this->parserCurrentIndex == $this->input_len - 1)) { break; }
 					$cc2 = $this->CharCode($this->parserCurrentIndex+1);
 					if ($cc2 == 47) {
 						// //, find lnfeed
@@ -145,14 +145,14 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 							return $this->fail("missing closing `*/`", $currentChunkStartIndex);
 						}
 					}
-					continue;
+					break;
 
 				// *, check for unmatched */
 				case 42:
 					if (($this->parserCurrentIndex < $this->input_len - 1) && ($this->CharCode($this->parserCurrentIndex+1) == 47)) {
 						return $this->fail("unmatched `/*`");
 					}
-					continue;
+					break;
 			}
 		}
 


### PR DESCRIPTION
continue statements within switch/case statements always have
behaved like break (ending the switch). Only exception is when
they are within a loop and we may want to use 'continue 2;'
instead (to jump to next iteration).

PHP7.3 has added a PHPWarning for all this switch/case/continue
uses (https://wiki.php.net/rfc/continue_on_switch_deprecation) so
this just changes is to the BC equivalent break. As far as there
isn't remaining code in the loop after the switch, it is 100%
the same than a continue 2.