### PR TITLE
Optimize cache generation speed and footprint

### DIFF
--- a/lib/Less/Environment.php
+++ b/lib/Less/Environment.php
@@ -17,7 +17,7 @@ class Less_Environment{
 	//public $processImports;				// option - whether to process imports. if false then imports will not be imported
 	//public $javascriptEnabled;			// option - whether JavaScript is enabled. if undefined, defaults to true
 	//public $useFileCache;					// browser only - whether to use the per file session cache
-	public $currentFileInfo;				// information about the current file - for error reporting and importing and making urls relative etc.
+	public static $currentFileInfo;				// information about the current file - for error reporting and importing and making urls relative etc.
 
 	public $importMultiple = false; 		// whether we are currently importing multiple copies
 

--- a/lib/Less/Functions.php
+++ b/lib/Less/Functions.php
@@ -911,7 +911,7 @@ class Less_Functions{
 		$DATA_URI_MAX_KB = 32;
 		$fileSizeInKB = round( strlen($buf) / 1024 );
 		if( $fileSizeInKB >= $DATA_URI_MAX_KB ){
-			$url = new Less_Tree_Url( ($filePathNode ? $filePathNode : $mimetypeNode), $this->currentFileInfo);
+			$url = new Less_Tree_Url( ($filePathNode ? $filePathNode : $mimetypeNode), $this->currentFileInfo['uri_root'] );
 			return $url->compile($this);
 		}
 

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -2084,7 +2084,7 @@ class Less_Parser{
 
 			if( $value && $this->parseEnd() ){
 				$this->forget();
-				return $this->NewObj6('Less_Tree_Rule',array( $name, $value, $important, $merge, $startOfRule, Less_Environment::$currentFileInfo));
+				return $this->NewObj5('Less_Tree_Rule',array( $name, $value, $important, $merge, $startOfRule));
 			}else{
 				$this->furthest = $this->pos;
 				$this->restore();
@@ -2190,7 +2190,7 @@ class Less_Parser{
 				$e = $this->parseValue();
 				if ($this->MatchChar(')')) {
 					if ($p && $e) {
-						$r = $this->NewObj7('Less_Tree_Rule', array( $p, $e, null, null, $this->pos, Less_Environment::$currentFileInfo, true));
+						$r = $this->NewObj6('Less_Tree_Rule', array( $p, $e, null, null, $this->pos, true));
 						$nodes[] = $this->NewObj1('Less_Tree_Paren',$r);
 					} elseif ($e) {
 						$nodes[] = $this->NewObj1('Less_Tree_Paren',$e);

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -2344,7 +2344,7 @@ class Less_Parser{
 
 		if( $rules || (!$hasBlock && $value && $this->MatchChar(';'))) {
 			$this->forget();
-			return $this->NewObj5('Less_Tree_Directive',array($name, $value, $rules, $index, Less_Environment::$currentFileInfo));
+			return $this->NewObj5('Less_Tree_Directive',array($name, $value, $rules, $index, Less_Environment::$currentFileInfo['reference']));
 		}
 
 		$this->restore();

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -1897,7 +1897,7 @@ class Less_Parser{
 		}
 
 		if( $elements ){
-			return $this->NewObj5('Less_Tree_Selector',array($elements, $extendList, $condition, $index, Less_Environment::$currentFileInfo));
+			return $this->NewObj5('Less_Tree_Selector',array($elements, $extendList, $condition, $index, Less_Environment::$currentFileInfo['reference']));
 		}
 		if( $extendList ) {
 			$this->Error('Extend must be used to extend a selector, it cannot be used on its own');

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -1213,7 +1213,7 @@ class Less_Parser{
 		}
 
 		if ($name) {
-			return $this->NewObj4('Less_Tree_Call',array($name, $args, $index, Less_Environment::$currentFileInfo) );
+			return $this->NewObj3('Less_Tree_Call',array($name, $args, $index) );
 		}
 	}
 

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -1499,7 +1499,7 @@ class Less_Parser{
 
 			if( $this->parseEnd() ){
 				$this->forget();
-				return $this->NewObj5('Less_Tree_Mixin_Call', array( $elements, $args, $index, Less_Environment::$currentFileInfo, $important));
+				return $this->NewObj5('Less_Tree_Mixin_Call', array( $elements, $args, $index, Less_Environment::$currentFileInfo['reference'], $important));
 			}
 		}
 

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -1307,7 +1307,7 @@ class Less_Parser{
 	private function parseEntitiesVariable(){
 		$index = $this->pos;
 		if ($this->PeekChar('@') && ($name = $this->MatchReg('/\\G@@?[\w-]+/'))) {
-			return $this->NewObj3('Less_Tree_Variable', array( $name[0], $index, Less_Environment::$currentFileInfo));
+			return $this->NewObj2('Less_Tree_Variable', array( $name[0], $index));
 		}
 	}
 
@@ -1317,7 +1317,7 @@ class Less_Parser{
 		$index = $this->pos;
 
 		if( $this->input_len > ($this->pos+1) && $this->input[$this->pos] === '@' && ($curly = $this->MatchReg('/\\G@\{([\w-]+)\}/')) ){
-			return $this->NewObj3('Less_Tree_Variable',array('@'.$curly[1], $index, Less_Environment::$currentFileInfo));
+			return $this->NewObj2('Less_Tree_Variable',array('@'.$curly[1], $index));
 		}
 	}
 
@@ -2628,7 +2628,7 @@ class Less_Parser{
 				if( !$s || $s[0] !== '@' ){
 					$name[$k] = $this->NewObj1('Less_Tree_Keyword',$s);
 				}else{
-					$name[$k] = $this->NewObj3('Less_Tree_Variable',array('@' . substr($s,2,-1), $index[$k], Less_Environment::$currentFileInfo));
+					$name[$k] = $this->NewObj2('Less_Tree_Variable',array('@' . substr($s,2,-1), $index[$k]));
 				}
 			}
 			return $name;

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -2701,7 +2701,7 @@ class Less_Parser{
 	public function NewObj1($class, $arg){
 		$obj = new $class( $arg );
 		if( $this->CacheEnabled() ){
-			$obj->cache_string = ' new '.$class.'('.Less_Parser::ArgString($arg).')';
+			$obj->cache_string = ' new '.$class.'('. (is_scalar($arg) ? var_export($arg, true) : Less_Parser::ArgString($arg)) .')';
 		}
 		return $obj;
 	}
@@ -2771,17 +2771,16 @@ class Less_Parser{
 	 */
 	public static function ArgString($arg){
 
-		$type = gettype($arg);
-
-		if( $type === 'object'){
+		if( is_object($arg) ){
 			$string = $arg->cache_string;
 			unset($arg->cache_string);
 			return $string;
 
-		}elseif( $type === 'array' ){
+		}
+		elseif( is_array($arg) ){
 			$string = ' Array(';
 			foreach($arg as $k => $a){
-				$string .= var_export($k,true).' => '.self::ArgString($a).',';
+				$string .= var_export($k,true).' => '.(is_scalar($a) ? var_export($a,true) : self::ArgString($a)).',';
 			}
 			return $string . ')';
 		}

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -2233,7 +2233,7 @@ class Less_Parser{
 			$rules = $this->parseBlock();
 
 			if( is_array($rules) ){
-				return $this->NewObj4('Less_Tree_Media',array( $rules, $features, $this->pos, Less_Environment::$currentFileInfo));
+				return $this->NewObj3('Less_Tree_Media',array( $rules, $features, $this->pos));
 			}
 		}
 	}

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -441,7 +441,7 @@ class Less_Parser{
 			$uri_root = dirname($file_uri);
 		}
 
-		$previousFileInfo = $this->env->currentFileInfo;
+		$previousFileInfo = Less_Environment::$currentFileInfo;
 		$uri_root = self::WinPath($uri_root);
 		$this->SetFileInfo($filename, $uri_root);
 
@@ -449,7 +449,7 @@ class Less_Parser{
 		$this->_parse();
 
 		if( $previousFileInfo ){
-			$this->env->currentFileInfo = $previousFileInfo;
+			Less_Environment::$currentFileInfo = $previousFileInfo;
 		}
 
 		return $this;
@@ -479,7 +479,7 @@ class Less_Parser{
 		}
 
 
-		$previousFileInfo = $this->env->currentFileInfo;
+		$previousFileInfo = Less_Environment::$currentFileInfo;
 
 
 		if( $filename ){
@@ -500,7 +500,7 @@ class Less_Parser{
 		}
 
 		if( $previousFileInfo ){
-			$this->env->currentFileInfo = $previousFileInfo;
+			Less_Environment::$currentFileInfo = $previousFileInfo;
 		}
 
 		return $return;
@@ -536,10 +536,10 @@ class Less_Parser{
 		$currentFileInfo = array();
 
 		//entry info
-		if( isset($this->env->currentFileInfo) ){
-			$currentFileInfo['entryPath'] = $this->env->currentFileInfo['entryPath'];
-			$currentFileInfo['entryUri'] = $this->env->currentFileInfo['entryUri'];
-			$currentFileInfo['rootpath'] = $this->env->currentFileInfo['rootpath'];
+		if( isset(Less_Environment::$currentFileInfo) ){
+			$currentFileInfo['entryPath'] = Less_Environment::$currentFileInfo['entryPath'];
+			$currentFileInfo['entryUri'] = Less_Environment::$currentFileInfo['entryUri'];
+			$currentFileInfo['rootpath'] = Less_Environment::$currentFileInfo['rootpath'];
 
 		}else{
 			$currentFileInfo['entryPath'] = $dirname;
@@ -554,11 +554,11 @@ class Less_Parser{
 
 
 		//inherit reference
-		if( isset($this->env->currentFileInfo['reference']) && $this->env->currentFileInfo['reference'] ){
+		if( isset(Less_Environment::$currentFileInfo['reference']) && Less_Environment::$currentFileInfo['reference'] ){
 			$currentFileInfo['reference'] = true;
 		}
 
-		$this->env->currentFileInfo = $currentFileInfo;
+		Less_Environment::$currentFileInfo = $currentFileInfo;
 	}
 
 
@@ -674,7 +674,7 @@ class Less_Parser{
 		$rules = $this->parsePrimary();
 
 		if( $this->pos < $this->input_len ){
-			throw new Less_Exception_Chunk($this->input, null, $this->furthest, $this->env->currentFileInfo);
+			throw new Less_Exception_Chunk($this->input, null, $this->furthest, Less_Environment::$currentFileInfo);
 		}
 
 		$this->UnsetInput();
@@ -730,8 +730,8 @@ class Less_Parser{
 		$this->input_len = strlen($this->input);
 
 
-		if( Less_Parser::$options['sourceMap'] && $this->env->currentFileInfo ){
-			$uri = $this->env->currentFileInfo['currentUri'];
+		if( Less_Parser::$options['sourceMap'] && Less_Environment::$currentFileInfo ){
+			$uri = Less_Environment::$currentFileInfo['currentUri'];
 			Less_Parser::$contentsMap[$uri] = $this->input;
 		}
 
@@ -1035,13 +1035,13 @@ class Less_Parser{
 
 		if( $this->input[$this->pos+1] === '/' ){
 			$match = $this->MatchReg('/\\G\/\/.*/');
-			return $this->NewObj4('Less_Tree_Comment',array($match[0], true, $this->pos, $this->env->currentFileInfo));
+			return $this->NewObj4('Less_Tree_Comment',array($match[0], true, $this->pos, Less_Environment::$currentFileInfo));
 		}
 
 		//$comment = $this->MatchReg('/\\G\/\*(?:[^*]|\*+[^\/*])*\*+\/\n?/');
 		$comment = $this->MatchReg('/\\G\/\*(?s).*?\*+\/\n?/');//not the same as less.js to prevent fatal errors
 		if( $comment ){
-			return $this->NewObj4('Less_Tree_Comment',array($comment[0], false, $this->pos, $this->env->currentFileInfo));
+			return $this->NewObj4('Less_Tree_Comment',array($comment[0], false, $this->pos, Less_Environment::$currentFileInfo));
 		}
 	}
 
@@ -1093,7 +1093,7 @@ class Less_Parser{
 		}
 
 		$quoted = $char.$matched.$char;
-		return $this->NewObj5('Less_Tree_Quoted',array($quoted, $matched, $e, $index, $this->env->currentFileInfo) );
+		return $this->NewObj5('Less_Tree_Quoted',array($quoted, $matched, $e, $index, Less_Environment::$currentFileInfo) );
 	}
 
 
@@ -1209,7 +1209,7 @@ class Less_Parser{
 		}
 
 		if ($name) {
-			return $this->NewObj4('Less_Tree_Call',array($name, $args, $index, $this->env->currentFileInfo) );
+			return $this->NewObj4('Less_Tree_Call',array($name, $args, $index, Less_Environment::$currentFileInfo) );
 		}
 	}
 
@@ -1285,10 +1285,10 @@ class Less_Parser{
 
 
 		if( isset($value->value) || $value instanceof Less_Tree_Variable ){
-			return $this->NewObj2('Less_Tree_Url',array($value, $this->env->currentFileInfo));
+			return $this->NewObj2('Less_Tree_Url',array($value, Less_Environment::$currentFileInfo));
 		}
 
-		return $this->NewObj2('Less_Tree_Url', array( $this->NewObj1('Less_Tree_Anonymous',$value), $this->env->currentFileInfo) );
+		return $this->NewObj2('Less_Tree_Url', array( $this->NewObj1('Less_Tree_Anonymous',$value), Less_Environment::$currentFileInfo) );
 	}
 
 
@@ -1303,7 +1303,7 @@ class Less_Parser{
 	private function parseEntitiesVariable(){
 		$index = $this->pos;
 		if ($this->PeekChar('@') && ($name = $this->MatchReg('/\\G@@?[\w-]+/'))) {
-			return $this->NewObj3('Less_Tree_Variable', array( $name[0], $index, $this->env->currentFileInfo));
+			return $this->NewObj3('Less_Tree_Variable', array( $name[0], $index, Less_Environment::$currentFileInfo));
 		}
 	}
 
@@ -1313,7 +1313,7 @@ class Less_Parser{
 		$index = $this->pos;
 
 		if( $this->input_len > ($this->pos+1) && $this->input[$this->pos] === '@' && ($curly = $this->MatchReg('/\\G@\{([\w-]+)\}/')) ){
-			return $this->NewObj3('Less_Tree_Variable',array('@'.$curly[1], $index, $this->env->currentFileInfo));
+			return $this->NewObj3('Less_Tree_Variable',array('@'.$curly[1], $index, Less_Environment::$currentFileInfo));
 		}
 	}
 
@@ -1495,7 +1495,7 @@ class Less_Parser{
 
 			if( $this->parseEnd() ){
 				$this->forget();
-				return $this->NewObj5('Less_Tree_Mixin_Call', array( $elements, $args, $index, $this->env->currentFileInfo, $important));
+				return $this->NewObj5('Less_Tree_Mixin_Call', array( $elements, $args, $index, Less_Environment::$currentFileInfo, $important));
 			}
 		}
 
@@ -1513,7 +1513,7 @@ class Less_Parser{
 			if( !$e ){
 				break;
 			}
-			$elements[] = $this->NewObj4('Less_Tree_Element', array($c, $e[0], $elemIndex, $this->env->currentFileInfo));
+			$elements[] = $this->NewObj4('Less_Tree_Element', array($c, $e[0], $elemIndex, Less_Environment::$currentFileInfo));
 			$c = $this->MatchChar('>');
 		}
 
@@ -1811,7 +1811,7 @@ class Less_Parser{
 		}
 
 		if( !is_null($e) ){
-			return $this->NewObj4('Less_Tree_Element',array( $c, $e, $index, $this->env->currentFileInfo));
+			return $this->NewObj4('Less_Tree_Element',array( $c, $e, $index, Less_Environment::$currentFileInfo));
 		}
 	}
 
@@ -1893,7 +1893,7 @@ class Less_Parser{
 		}
 
 		if( $elements ){
-			return $this->NewObj5('Less_Tree_Selector',array($elements, $extendList, $condition, $index, $this->env->currentFileInfo));
+			return $this->NewObj5('Less_Tree_Selector',array($elements, $extendList, $condition, $index, Less_Environment::$currentFileInfo));
 		}
 		if( $extendList ) {
 			$this->Error('Extend must be used to extend a selector, it cannot be used on its own');
@@ -2023,7 +2023,7 @@ class Less_Parser{
 				$match[2] .= ' !important';
 			}
 
-			return $this->NewObj4('Less_Tree_NameValue',array( $match[1], $match[2], $index, $this->env->currentFileInfo));
+			return $this->NewObj4('Less_Tree_NameValue',array( $match[1], $match[2], $index, Less_Environment::$currentFileInfo));
 		}
 
 		$this->restore();
@@ -2080,7 +2080,7 @@ class Less_Parser{
 
 			if( $value && $this->parseEnd() ){
 				$this->forget();
-				return $this->NewObj6('Less_Tree_Rule',array( $name, $value, $important, $merge, $startOfRule, $this->env->currentFileInfo));
+				return $this->NewObj6('Less_Tree_Rule',array( $name, $value, $important, $merge, $startOfRule, Less_Environment::$currentFileInfo));
 			}else{
 				$this->furthest = $this->pos;
 				$this->restore();
@@ -2129,7 +2129,7 @@ class Less_Parser{
 					}
 
 					$this->forget();
-					return $this->NewObj5('Less_Tree_Import',array( $path, $features, $options, $this->pos, $this->env->currentFileInfo));
+					return $this->NewObj5('Less_Tree_Import',array( $path, $features, $options, $this->pos, Less_Environment::$currentFileInfo));
 				}
 			}
 		}
@@ -2186,7 +2186,7 @@ class Less_Parser{
 				$e = $this->parseValue();
 				if ($this->MatchChar(')')) {
 					if ($p && $e) {
-						$r = $this->NewObj7('Less_Tree_Rule', array( $p, $e, null, null, $this->pos, $this->env->currentFileInfo, true));
+						$r = $this->NewObj7('Less_Tree_Rule', array( $p, $e, null, null, $this->pos, Less_Environment::$currentFileInfo, true));
 						$nodes[] = $this->NewObj1('Less_Tree_Paren',$r);
 					} elseif ($e) {
 						$nodes[] = $this->NewObj1('Less_Tree_Paren',$e);
@@ -2229,7 +2229,7 @@ class Less_Parser{
 			$rules = $this->parseBlock();
 
 			if( is_array($rules) ){
-				return $this->NewObj4('Less_Tree_Media',array( $rules, $features, $this->pos, $this->env->currentFileInfo));
+				return $this->NewObj4('Less_Tree_Media',array( $rules, $features, $this->pos, Less_Environment::$currentFileInfo));
 			}
 		}
 	}
@@ -2340,7 +2340,7 @@ class Less_Parser{
 
 		if( $rules || (!$hasBlock && $value && $this->MatchChar(';'))) {
 			$this->forget();
-			return $this->NewObj5('Less_Tree_Directive',array($name, $value, $rules, $index, $this->env->currentFileInfo));
+			return $this->NewObj5('Less_Tree_Directive',array($name, $value, $rules, $index, Less_Environment::$currentFileInfo));
 		}
 
 		$this->restore();
@@ -2624,7 +2624,7 @@ class Less_Parser{
 				if( !$s || $s[0] !== '@' ){
 					$name[$k] = $this->NewObj1('Less_Tree_Keyword',$s);
 				}else{
-					$name[$k] = $this->NewObj3('Less_Tree_Variable',array('@' . substr($s,2,-1), $index[$k], $this->env->currentFileInfo));
+					$name[$k] = $this->NewObj3('Less_Tree_Variable',array('@' . substr($s,2,-1), $index[$k], Less_Environment::$currentFileInfo));
 				}
 			}
 			return $name;
@@ -2789,7 +2789,7 @@ class Less_Parser{
 	}
 
 	public function Error($msg){
-		throw new Less_Exception_Parser($msg, null, $this->furthest, $this->env->currentFileInfo);
+		throw new Less_Exception_Parser($msg, null, $this->furthest, Less_Environment::$currentFileInfo);
 	}
 
 	public static function WinPath($path){

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -465,7 +465,7 @@ class Less_Parser{
 	 * @param bool $returnRoot Indicates whether the return value should be a css string a root node
 	 * @return Less_Tree_Ruleset|Less_Parser
 	 */
-	public function parseFile( $filename, $uri_root = '', $returnRoot = false){
+	public function parseFile( $filename, $uri_root = '', $returnRoot = false, $reference = null){
 
 		if( !file_exists($filename) ){
 			$this->Error(sprintf('File `%s` not found.', $filename));
@@ -488,6 +488,9 @@ class Less_Parser{
 		$uri_root = self::WinPath($uri_root);
 
 		$this->SetFileInfo($filename, $uri_root);
+		if (!is_null($reference)) {
+			Less_Environment::$currentFileInfo['reference'] = $reference;
+		}
 
 		self::AddParsedFile($filename);
 

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -1097,7 +1097,7 @@ class Less_Parser{
 		}
 
 		$quoted = $char.$matched.$char;
-		return $this->NewObj5('Less_Tree_Quoted',array($quoted, $matched, $e, $index, Less_Environment::$currentFileInfo) );
+		return $this->NewObj4('Less_Tree_Quoted',array($quoted, $matched, $e, $index) );
 	}
 
 

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -1517,7 +1517,7 @@ class Less_Parser{
 			if( !$e ){
 				break;
 			}
-			$elements[] = $this->NewObj4('Less_Tree_Element', array($c, $e[0], $elemIndex, Less_Environment::$currentFileInfo));
+			$elements[] = $this->NewObj3('Less_Tree_Element', array($c, $e[0], $elemIndex));
 			$c = $this->MatchChar('>');
 		}
 
@@ -1815,7 +1815,7 @@ class Less_Parser{
 		}
 
 		if( !is_null($e) ){
-			return $this->NewObj4('Less_Tree_Element',array( $c, $e, $index, Less_Environment::$currentFileInfo));
+			return $this->NewObj3('Less_Tree_Element',array( $c, $e, $index));
 		}
 	}
 

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -554,6 +554,7 @@ class Less_Parser{
 		$currentFileInfo['currentUri'] = $uri_root.basename($filename);
 		$currentFileInfo['filename'] = $filename;
 		$currentFileInfo['uri_root'] = $uri_root;
+		$currentFileInfo['reference'] = null;
 
 
 		//inherit reference
@@ -1038,13 +1039,13 @@ class Less_Parser{
 
 		if( $this->input[$this->pos+1] === '/' ){
 			$match = $this->MatchReg('/\\G\/\/.*/');
-			return $this->NewObj4('Less_Tree_Comment',array($match[0], true, $this->pos, Less_Environment::$currentFileInfo));
+			return $this->NewObj4('Less_Tree_Comment',array($match[0], true, $this->pos, Less_Environment::$currentFileInfo['reference']));
 		}
 
 		//$comment = $this->MatchReg('/\\G\/\*(?:[^*]|\*+[^\/*])*\*+\/\n?/');
 		$comment = $this->MatchReg('/\\G\/\*(?s).*?\*+\/\n?/');//not the same as less.js to prevent fatal errors
 		if( $comment ){
-			return $this->NewObj4('Less_Tree_Comment',array($comment[0], false, $this->pos, Less_Environment::$currentFileInfo));
+			return $this->NewObj4('Less_Tree_Comment',array($comment[0], false, $this->pos, Less_Environment::$currentFileInfo['reference']));
 		}
 	}
 

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -2027,7 +2027,7 @@ class Less_Parser{
 				$match[2] .= ' !important';
 			}
 
-			return $this->NewObj4('Less_Tree_NameValue',array( $match[1], $match[2], $index, Less_Environment::$currentFileInfo));
+			return $this->NewObj3('Less_Tree_NameValue',array( $match[1], $match[2], $index));
 		}
 
 		$this->restore();

--- a/lib/Less/Parser.php
+++ b/lib/Less/Parser.php
@@ -1289,10 +1289,10 @@ class Less_Parser{
 
 
 		if( isset($value->value) || $value instanceof Less_Tree_Variable ){
-			return $this->NewObj2('Less_Tree_Url',array($value, Less_Environment::$currentFileInfo));
+			return $this->NewObj2('Less_Tree_Url', array($value, Less_Environment::$currentFileInfo['uri_root']) );
 		}
 
-		return $this->NewObj2('Less_Tree_Url', array( $this->NewObj1('Less_Tree_Anonymous',$value), Less_Environment::$currentFileInfo) );
+		return $this->NewObj2('Less_Tree_Url', array($this->NewObj1('Less_Tree_Anonymous',$value), Less_Environment::$currentFileInfo['uri_root']) );
 	}
 
 

--- a/lib/Less/Tree/Anonymous.php
+++ b/lib/Less/Tree/Anonymous.php
@@ -11,22 +11,20 @@ class Less_Tree_Anonymous extends Less_Tree{
 	public $quote;
 	public $index;
 	public $mapLines;
-	public $currentFileInfo;
 	public $type = 'Anonymous';
 
 	/**
 	 * @param integer $index
 	 * @param boolean $mapLines
 	 */
-	public function __construct($value, $index = null, $currentFileInfo = null, $mapLines = null ){
+	public function __construct($value, $index = null, $mapLines = null ){
 		$this->value = $value;
 		$this->index = $index;
 		$this->mapLines = $mapLines;
-		$this->currentFileInfo = $currentFileInfo;
 	}
 
 	public function compile(){
-		return new Less_Tree_Anonymous($this->value, $this->index, $this->currentFileInfo, $this->mapLines);
+		return new Less_Tree_Anonymous($this->value, $this->index, $this->mapLines);
 	}
 
     public function compare($x){
@@ -48,7 +46,7 @@ class Less_Tree_Anonymous extends Less_Tree{
      * @see Less_Tree::genCSS
      */
 	public function genCSS( $output ){
-		$output->add( $this->value, $this->currentFileInfo, $this->index, $this->mapLines );
+		$output->add( $this->value, Less_Environment::$currentFileInfo, $this->index, $this->mapLines );
 	}
 
 	public function toCSS(){

--- a/lib/Less/Tree/Call.php
+++ b/lib/Less/Tree/Call.php
@@ -13,14 +13,12 @@ class Less_Tree_Call extends Less_Tree{
     public $name;
     public $args;
     public $index;
-    public $currentFileInfo;
     public $type = 'Call';
 
-	public function __construct($name, $args, $index, $currentFileInfo = null ){
+	public function __construct($name, $args, $index){
 		$this->name = $name;
 		$this->args = $args;
 		$this->index = $index;
-		$this->currentFileInfo = $currentFileInfo;
 	}
 
     public function accept( $visitor ){
@@ -73,7 +71,7 @@ class Less_Tree_Call extends Less_Tree{
 			if( method_exists('Less_Functions',$nameLC) ){ // 1.
 				try {
 
-					$func = new Less_Functions($env, $this->currentFileInfo);
+					$func = new Less_Functions($env, Less_Environment::$currentFileInfo);
 					$result = call_user_func_array( array($func,$nameLC),$args);
 
 				} catch (Exception $e) {
@@ -93,7 +91,7 @@ class Less_Tree_Call extends Less_Tree{
 		}
 
 
-		return new Less_Tree_Call( $this->name, $args, $this->index, $this->currentFileInfo );
+		return new Less_Tree_Call( $this->name, $args, $this->index);
     }
 
     /**
@@ -101,7 +99,7 @@ class Less_Tree_Call extends Less_Tree{
      */
 	public function genCSS( $output ){
 
-		$output->add( $this->name . '(', $this->currentFileInfo, $this->index );
+		$output->add( $this->name . '(', Less_Environment::$currentFileInfo, $this->index );
 		$args_len = count($this->args);
 		for($i = 0; $i < $args_len; $i++ ){
 			$this->args[$i]->genCSS( $output );

--- a/lib/Less/Tree/Comment.php
+++ b/lib/Less/Tree/Comment.php
@@ -10,14 +10,14 @@ class Less_Tree_Comment extends Less_Tree{
 
 	public $value;
 	public $silent;
+	public $reference;
 	public $isReferenced;
-	public $currentFileInfo;
 	public $type = 'Comment';
 
-	public function __construct($value, $silent, $index = null, $currentFileInfo = null ){
+	public function __construct($value, $silent, $index = null, $reference=null){
 		$this->value = $value;
 		$this->silent = !! $silent;
-		$this->currentFileInfo = $currentFileInfo;
+		$this->reference = $reference;
 	}
 
     /**
@@ -25,7 +25,7 @@ class Less_Tree_Comment extends Less_Tree{
      */
 	public function genCSS( $output ){
 		//if( $this->debugInfo ){
-			//$output->add( tree.debugInfo($env, $this), $this->currentFileInfo, $this->index);
+			//$output->add( tree.debugInfo($env, $this), Less_Environment::$currentFileInfo, $this->index);
 		//}
 		$output->add( trim($this->value) );//TODO shouldn't need to trim, we shouldn't grab the \n
 	}
@@ -35,7 +35,7 @@ class Less_Tree_Comment extends Less_Tree{
 	}
 
 	public function isSilent(){
-		$isReference = ($this->currentFileInfo && isset($this->currentFileInfo['reference']) && (!isset($this->isReferenced) || !$this->isReferenced) );
+		$isReference = (isset($this->reference) && $this->reference && (!isset($this->isReferenced) || !$this->isReferenced) );
 		$isCompressed = Less_Parser::$options['compress'] && !preg_match('/^\/\*!/', $this->value);
 		return $this->silent || $isReference || $isCompressed;
 	}

--- a/lib/Less/Tree/Directive.php
+++ b/lib/Less/Tree/Directive.php
@@ -12,12 +12,12 @@ class Less_Tree_Directive extends Less_Tree{
 	public $value;
 	public $rules;
 	public $index;
+	public $reference;
 	public $isReferenced;
-	public $currentFileInfo;
 	public $debugInfo;
 	public $type = 'Directive';
 
-	public function __construct($name, $value = null, $rules, $index = null, $currentFileInfo = null, $debugInfo = null ){
+	public function __construct($name, $value = null, $rules, $index = null, $reference = null, $debugInfo = null ){
 		$this->name = $name;
 		$this->value = $value;
 		if( $rules ){
@@ -26,7 +26,7 @@ class Less_Tree_Directive extends Less_Tree{
 		}
 
 		$this->index = $index;
-		$this->currentFileInfo = $currentFileInfo;
+		$this->reference = $reference;
 		$this->debugInfo = $debugInfo;
 	}
 
@@ -47,7 +47,7 @@ class Less_Tree_Directive extends Less_Tree{
     public function genCSS( $output ){
 		$value = $this->value;
 		$rules = $this->rules;
-		$output->add( $this->name, $this->currentFileInfo, $this->index );
+		$output->add( $this->name, Less_Environment::$currentFileInfo, $this->index );
 		if( $this->value ){
 			$output->add(' ');
 			$this->value->genCSS($output);
@@ -72,7 +72,7 @@ class Less_Tree_Directive extends Less_Tree{
 			$rules->root = true;
 		}
 
-		return new Less_Tree_Directive( $this->name, $value, $rules, $this->index, $this->currentFileInfo, $this->debugInfo );
+		return new Less_Tree_Directive( $this->name, $value, $rules, $this->index, $this->reference, $this->debugInfo );
 	}
 
 
@@ -95,6 +95,10 @@ class Less_Tree_Directive extends Less_Tree{
 		if( $this->rules ){
 			Less_Tree::ReferencedArray($this->rules->rules);
 		}
+	}
+
+	public function getIsReferenced(){
+		return !isset($this->reference) || !$this->reference || $this->isReferenced;
 	}
 
 }

--- a/lib/Less/Tree/Element.php
+++ b/lib/Less/Tree/Element.php
@@ -11,12 +11,11 @@ class Less_Tree_Element extends Less_Tree{
 	public $combinator = '';
 	public $value = '';
 	public $index;
-	public $currentFileInfo;
 	public $type = 'Element';
 
 	public $value_is_object = false;
 
-	public function __construct($combinator, $value, $index = null, $currentFileInfo = null ){
+	public function __construct($combinator, $value, $index = null ){
 
 		$this->value = $value;
 		$this->value_is_object = is_object($value);
@@ -26,7 +25,6 @@ class Less_Tree_Element extends Less_Tree{
 		}
 
 		$this->index = $index;
-		$this->currentFileInfo = $currentFileInfo;
 	}
 
     public function accept( $visitor ){
@@ -38,7 +36,7 @@ class Less_Tree_Element extends Less_Tree{
 	public function compile($env){
 
 		if( Less_Environment::$mixin_stack ){
-			return new Less_Tree_Element($this->combinator, ($this->value_is_object ? $this->value->compile($env) : $this->value), $this->index, $this->currentFileInfo );
+			return new Less_Tree_Element($this->combinator, ($this->value_is_object ? $this->value->compile($env) : $this->value), $this->index );
 		}
 
 		if( $this->value_is_object ){
@@ -52,7 +50,7 @@ class Less_Tree_Element extends Less_Tree{
      * @see Less_Tree::genCSS
      */
 	public function genCSS( $output ){
-		$output->add( $this->toCSS(), $this->currentFileInfo, $this->index );
+		$output->add( $this->toCSS(), Less_Environment::$currentFileInfo, $this->index );
 	}
 
 	public function toCSS(){

--- a/lib/Less/Tree/Import.php
+++ b/lib/Less/Tree/Import.php
@@ -173,7 +173,7 @@ class Less_Tree_Import extends Less_Tree{
 			//$contents = new Less_Tree_Anonymous($this->root, 0, array('filename'=>$this->importedFilename), true );
 
 			Less_Parser::AddParsedFile($full_path);
-			$contents = new Less_Tree_Anonymous( file_get_contents($full_path), 0, array(), true );
+			$contents = new Less_Tree_Anonymous( file_get_contents($full_path), 0, true );
 
 			if( $this->features ){
 				return new Less_Tree_Media( array($contents), $this->features->value );

--- a/lib/Less/Tree/Import.php
+++ b/lib/Less/Tree/Import.php
@@ -261,11 +261,10 @@ class Less_Tree_Import extends Less_Tree{
 	 * @return Less_Tree_Media|array
 	 */
     public function ParseImport( $full_path, $uri, $env ){
-
-    $previousFileInfo = Less_Environment::$currentFileInfo;
+		$previousReference = Less_Environment::$currentFileInfo['reference'];
 		$import_env = clone $env;
 		$reference = null;
-		if( (isset($this->options['reference']) && $this->options['reference']) || isset($this->currentFileInfo['reference']) ){
+		if( (isset($this->options['reference']) && $this->options['reference']) || (isset($this->currentFileInfo['reference']) && $this->currentFileInfo['reference']) ){
 			$reference = true;
 			Less_Environment::$currentFileInfo['reference'] = true;
 		}
@@ -281,7 +280,7 @@ class Less_Tree_Import extends Less_Tree{
 		$ruleset = new Less_Tree_Ruleset(array(), $root->rules );
 		$ruleset->evalImports($import_env);
 
-    Less_Environment::$currentFileInfo = $previousFileInfo;
+		Less_Environment::$currentFileInfo['reference'] = $previousReference;
 		return $this->features ? new Less_Tree_Media($ruleset->rules, $this->features->value) : $ruleset->rules;
 	}
 

--- a/lib/Less/Tree/Import.php
+++ b/lib/Less/Tree/Import.php
@@ -262,9 +262,12 @@ class Less_Tree_Import extends Less_Tree{
 	 */
     public function ParseImport( $full_path, $uri, $env ){
 
+    $previousFileInfo = Less_Environment::$currentFileInfo;
 		$import_env = clone $env;
+		$reference = null;
 		if( (isset($this->options['reference']) && $this->options['reference']) || isset($this->currentFileInfo['reference']) ){
-			$import_env->currentFileInfo['reference'] = true;
+			$reference = true;
+			Less_Environment::$currentFileInfo['reference'] = true;
 		}
 
 		if( (isset($this->options['multiple']) && $this->options['multiple']) ){
@@ -272,12 +275,13 @@ class Less_Tree_Import extends Less_Tree{
 		}
 
 		$parser = new Less_Parser($import_env);
-		$root = $parser->parseFile($full_path, $uri, true);
+		$root = $parser->parseFile($full_path, $uri, true, $reference);
 
 
 		$ruleset = new Less_Tree_Ruleset(array(), $root->rules );
 		$ruleset->evalImports($import_env);
 
+    Less_Environment::$currentFileInfo = $previousFileInfo;
 		return $this->features ? new Less_Tree_Media($ruleset->rules, $this->features->value) : $ruleset->rules;
 	}
 

--- a/lib/Less/Tree/Media.php
+++ b/lib/Less/Tree/Media.php
@@ -82,7 +82,7 @@ class Less_Tree_Media extends Less_Tree{
 
 	public function emptySelectors(){
 		$el = new Less_Tree_Element('','&', $this->index);
-		$sels = array( new Less_Tree_Selector(array($el), array(), null, $this->index, $this->currentFileInfo) );
+		$sels = array( new Less_Tree_Selector(array($el), array(), null, $this->index, Less_Environment::$currentFileInfo['reference']) );
 		$sels[0]->mediaEmpty = true;
         return $sels;
 	}

--- a/lib/Less/Tree/Media.php
+++ b/lib/Less/Tree/Media.php
@@ -81,7 +81,7 @@ class Less_Tree_Media extends Less_Tree{
 	}
 
 	public function emptySelectors(){
-		$el = new Less_Tree_Element('','&', $this->index, $this->currentFileInfo );
+		$el = new Less_Tree_Element('','&', $this->index);
 		$sels = array( new Less_Tree_Selector(array($el), array(), null, $this->index, $this->currentFileInfo) );
 		$sels[0]->mediaEmpty = true;
         return $sels;

--- a/lib/Less/Tree/Media.php
+++ b/lib/Less/Tree/Media.php
@@ -11,14 +11,12 @@ class Less_Tree_Media extends Less_Tree{
 	public $features;
 	public $rules;
 	public $index;
-	public $currentFileInfo;
 	public $isReferenced;
 	public $type = 'Media';
 
-	public function __construct($value = array(), $features = array(), $index = null, $currentFileInfo = null ){
+	public function __construct($value = array(), $features = array(), $index = null){
 
 		$this->index = $index;
-		$this->currentFileInfo = $currentFileInfo;
 
 		$selectors = $this->emptySelectors();
 
@@ -38,7 +36,7 @@ class Less_Tree_Media extends Less_Tree{
      */
     public function genCSS( $output ){
 
-		$output->add( '@media ', $this->currentFileInfo, $this->index );
+		$output->add( '@media ', Less_Environment::$currentFileInfo, $this->index );
 		$this->features->genCSS( $output );
 		Less_Tree::outputRuleset( $output, $this->rules);
 
@@ -46,7 +44,7 @@ class Less_Tree_Media extends Less_Tree{
 
 	public function compile($env) {
 
-		$media = new Less_Tree_Media(array(), array(), $this->index, $this->currentFileInfo );
+		$media = new Less_Tree_Media(array(), array(), $this->index );
 
 		$strictMathBypass = false;
 		if( Less_Parser::$options['strictMath'] === false) {

--- a/lib/Less/Tree/Mixin/Call.php
+++ b/lib/Less/Tree/Mixin/Call.php
@@ -6,7 +6,7 @@ class Less_Tree_Mixin_Call extends Less_Tree{
 	public $selector;
 	public $arguments;
 	public $index;
-	public $currentFileInfo;
+	public $reference;
 
 	public $important;
 	public $type = 'MixinCall';
@@ -15,11 +15,11 @@ class Less_Tree_Mixin_Call extends Less_Tree{
 	 * less.js: tree.mixin.Call
 	 *
 	 */
-	public function __construct($elements, $args, $index, $currentFileInfo, $important = false){
+	public function __construct($elements, $args, $index, $reference = null, $important = false){
 		$this->selector = new Less_Tree_Selector($elements);
 		$this->arguments = $args;
 		$this->index = $index;
-		$this->currentFileInfo = $currentFileInfo;
+		$this->reference = $reference;
 		$this->important = $important;
 	}
 
@@ -126,14 +126,14 @@ class Less_Tree_Mixin_Call extends Less_Tree{
 						}
 						$rules = array_merge($rules, $mixin->evalCall($env, $args, $this->important)->rules);
 					} catch (Exception $e) {
-						//throw new Less_Exception_Compiler($e->getMessage(), $e->index, null, $this->currentFileInfo['filename']);
-						throw new Less_Exception_Compiler($e->getMessage(), null, null, $this->currentFileInfo);
+						//throw new Less_Exception_Compiler($e->getMessage(), $e->index, null, Less_Environment::$currentFileInfo['filename']);
+						throw new Less_Exception_Compiler($e->getMessage(), null, null, Less_Environment::$currentFileInfo);
 					}
 				}
 			}
 
 			if( $match ){
-				if( !$this->currentFileInfo || !isset($this->currentFileInfo['reference']) || !$this->currentFileInfo['reference'] ){
+				if( !isset($this->reference) or !$this->reference){
 					Less_Tree::ReferencedArray($rules);
 				}
 
@@ -142,10 +142,10 @@ class Less_Tree_Mixin_Call extends Less_Tree{
 		}
 
 		if( $isOneFound ){
-			throw new Less_Exception_Compiler('No matching definition was found for `'.$this->Format( $args ).'`', null, $this->index, $this->currentFileInfo);
+			throw new Less_Exception_Compiler('No matching definition was found for `'.$this->Format( $args ).'`', null, $this->index, Less_Environment::$currentFileInfo);
 
 		}else{
-			throw new Less_Exception_Compiler(trim($this->selector->toCSS()) . " is undefined in ".$this->currentFileInfo['filename'], null, $this->index);
+			throw new Less_Exception_Compiler(trim($this->selector->toCSS()) . " is undefined in ".Less_Environment::$currentFileInfo['filename'], null, $this->index);
 		}
 
 	}

--- a/lib/Less/Tree/NameValue.php
+++ b/lib/Less/Tree/NameValue.php
@@ -15,15 +15,13 @@ class Less_Tree_NameValue extends Less_Tree{
 	public $name;
 	public $value;
 	public $index;
-	public $currentFileInfo;
 	public $type = 'NameValue';
 	public $important = '';
 
-	public function __construct($name, $value = null, $index = null, $currentFileInfo = null ){
+	public function __construct($name, $value = null, $index = null){
 		$this->name = $name;
 		$this->value = $value;
 		$this->index = $index;
-		$this->currentFileInfo = $currentFileInfo;
 	}
 
     public function genCSS( $output ){
@@ -34,7 +32,7 @@ class Less_Tree_NameValue extends Less_Tree{
 			. $this->value
 			. $this->important
 			. (((Less_Environment::$lastRule && Less_Parser::$options['compress'])) ? "" : ";")
-			, $this->currentFileInfo, $this->index);
+			, Less_Environment::$currentFileInfo, $this->index);
 	}
 
 	public function compile ($env){
@@ -42,7 +40,7 @@ class Less_Tree_NameValue extends Less_Tree{
 	}
 
 	public function makeImportant(){
-		$new = new Less_Tree_NameValue($this->name, $this->value, $this->index, $this->currentFileInfo);
+		$new = new Less_Tree_NameValue($this->name, $this->value, $this->index);
 		$new->important = ' !important';
 		return $new;
 	}

--- a/lib/Less/Tree/Quoted.php
+++ b/lib/Less/Tree/Quoted.php
@@ -11,20 +11,18 @@ class Less_Tree_Quoted extends Less_Tree{
 	public $value;
 	public $quote;
 	public $index;
-	public $currentFileInfo;
 	public $type = 'Quoted';
 
 	/**
 	 * @param string $str
 	 */
-	public function __construct($str, $content = '', $escaped = false, $index = false, $currentFileInfo = null ){
+	public function __construct($str, $content = '', $escaped = false, $index = false){
 		$this->escaped = $escaped;
 		$this->value = $content;
 		if( $str ){
 			$this->quote = $str[0];
 		}
 		$this->index = $index;
-		$this->currentFileInfo = $currentFileInfo;
 	}
 
     /**
@@ -32,7 +30,7 @@ class Less_Tree_Quoted extends Less_Tree{
      */
     public function genCSS( $output ){
 		if( !$this->escaped ){
-			$output->add( $this->quote, $this->currentFileInfo, $this->index );
+			$output->add( $this->quote, Less_Environment::$currentFileInfo, $this->index );
         }
         $output->add( $this->value );
         if( !$this->escaped ){
@@ -60,7 +58,7 @@ class Less_Tree_Quoted extends Less_Tree{
 			}
 		}
 
-		return new Less_Tree_Quoted($this->quote . $value . $this->quote, $value, $this->escaped, $this->index, $this->currentFileInfo);
+		return new Less_Tree_Quoted($this->quote . $value . $this->quote, $value, $this->escaped, $this->index);
 	}
 
     public function compare($x) {

--- a/lib/Less/Tree/Quoted.php
+++ b/lib/Less/Tree/Quoted.php
@@ -53,7 +53,7 @@ class Less_Tree_Quoted extends Less_Tree{
 
 		if( preg_match_all('/@\{([\w-]+)\}/',$value,$matches) ){
 			foreach($matches[1] as $i => $match){
-				$v = new Less_Tree_Variable('@' . $match, $this->index, $this->currentFileInfo );
+				$v = new Less_Tree_Variable('@' . $match, $this->index);
 				$v = $v->compile($env);
 				$v = ($v instanceof Less_Tree_Quoted) ? $v->value : $v->toCSS();
 				$value = str_replace($matches[0][$i], $v, $value);

--- a/lib/Less/Tree/Rule.php
+++ b/lib/Less/Tree/Rule.php
@@ -15,19 +15,17 @@ class Less_Tree_Rule extends Less_Tree{
 	public $index;
 	public $inline;
 	public $variable;
-	public $currentFileInfo;
 	public $type = 'Rule';
 
 	/**
 	 * @param string $important
 	 */
-	public function __construct($name, $value = null, $important = null, $merge = null, $index = null, $currentFileInfo = null,  $inline = false){
+	public function __construct($name, $value = null, $important = null, $merge = null, $index = null, $inline = false){
 		$this->name = $name;
 		$this->value = ($value instanceof Less_Tree_Value || $value instanceof Less_Tree_Ruleset) ? $value : new Less_Tree_Value(array($value));
 		$this->important = $important ? ' ' . trim($important) : '';
 		$this->merge = $merge;
 		$this->index = $index;
-		$this->currentFileInfo = $currentFileInfo;
 		$this->inline = $inline;
 		$this->variable = ( is_string($name) && $name[0] === '@');
 	}
@@ -41,16 +39,16 @@ class Less_Tree_Rule extends Less_Tree{
      */
     public function genCSS( $output ){
 
-		$output->add( $this->name . Less_Environment::$_outputMap[': '], $this->currentFileInfo, $this->index);
+		$output->add( $this->name . Less_Environment::$_outputMap[': '], Less_Environment::$currentFileInfo, $this->index);
 		try{
 			$this->value->genCSS( $output);
 
 		}catch( Less_Exception_Parser $e ){
 			$e->index = $this->index;
-			$e->currentFile = $this->currentFileInfo;
+			$e->currentFile = Less_Environment::$currentFileInfo;
 			throw $e;
 		}
-		$output->add( $this->important . (($this->inline || (Less_Environment::$lastRule && Less_Parser::$options['compress'])) ? "" : ";"), $this->currentFileInfo, $this->index);
+		$output->add( $this->important . (($this->inline || (Less_Environment::$lastRule && Less_Parser::$options['compress'])) ? "" : ";"), Less_Environment::$currentFileInfo, $this->index);
 	}
 
 	public function compile ($env){
@@ -75,11 +73,11 @@ class Less_Tree_Rule extends Less_Tree{
 			$evaldValue = $this->value->compile($env);
 
 			if( !$this->variable && $evaldValue->type === "DetachedRuleset") {
-				throw new Less_Exception_Compiler("Rulesets cannot be evaluated on a property.", null, $this->index, $this->currentFileInfo);
+				throw new Less_Exception_Compiler("Rulesets cannot be evaluated on a property.", null, $this->index, Less_Environment::$currentFileInfo);
 			}
 
 			if( Less_Environment::$mixin_stack ){
-				$return = new Less_Tree_Rule($name, $evaldValue, $this->important, $this->merge, $this->index, $this->currentFileInfo, $this->inline);
+				$return = new Less_Tree_Rule($name, $evaldValue, $this->important, $this->merge, $this->index, $this->inline);
 			}else{
 				$this->name = $name;
 				$this->value = $evaldValue;
@@ -89,7 +87,7 @@ class Less_Tree_Rule extends Less_Tree{
 		}catch( Less_Exception_Parser $e ){
 			if( !is_numeric($e->index) ){
 				$e->index = $this->index;
-				$e->currentFile = $this->currentFileInfo;
+				$e->currentFile = Less_Environment::$currentFileInfo;
 			}
 			throw $e;
 		}
@@ -109,7 +107,7 @@ class Less_Tree_Rule extends Less_Tree{
 	}
 
     public function makeImportant(){
-		return new Less_Tree_Rule($this->name, $this->value, '!important', $this->merge, $this->index, $this->currentFileInfo, $this->inline);
+		return new Less_Tree_Rule($this->name, $this->value, '!important', $this->merge, $this->index, $this->inline);
 	}
 
 }

--- a/lib/Less/Tree/Ruleset.php
+++ b/lib/Less/Tree/Ruleset.php
@@ -547,7 +547,7 @@ class Less_Tree_Ruleset extends Less_Tree{
 						// it is not lost
 						if( $sel ){
 							$sel[0]->elements = array_slice($sel[0]->elements,0);
-							$sel[0]->elements[] = new Less_Tree_Element($el->combinator, '', $el->index, $el->currentFileInfo );
+							$sel[0]->elements[] = new Less_Tree_Element($el->combinator, '', $el->index );
 						}
 						$selectorsMultiplied[] = $sel;
 					}else {
@@ -584,7 +584,7 @@ class Less_Tree_Ruleset extends Less_Tree{
 								$newJoinedSelectorEmpty = false;
 
 								// join the elements so far with the first part of the parent
-								$newJoinedSelector->elements[] = new Less_Tree_Element( $el->combinator, $parentSel[0]->elements[0]->value, $el->index, $el->currentFileInfo);
+								$newJoinedSelector->elements[] = new Less_Tree_Element( $el->combinator, $parentSel[0]->elements[0]->value, $el->index );
 
 								$newJoinedSelector->elements = array_merge( $newJoinedSelector->elements, array_slice($parentSel[0]->elements, 1) );
 							}

--- a/lib/Less/Tree/Selector.php
+++ b/lib/Less/Tree/Selector.php
@@ -15,7 +15,7 @@ class Less_Tree_Selector extends Less_Tree{
 	public $index;
 	public $evaldCondition = false;
 	public $type = 'Selector';
-	public $currentFileInfo = array();
+	public $reference;
 	public $isReferenced;
 	public $mediaEmpty;
 
@@ -28,16 +28,14 @@ class Less_Tree_Selector extends Less_Tree{
 	/**
 	 * @param boolean $isReferenced
 	 */
-	public function __construct( $elements, $extendList = array() , $condition = null, $index=null, $currentFileInfo=null, $isReferenced=null ){
+	public function __construct( $elements, $extendList = array() , $condition = null, $index=null, $reference=null, $isReferenced=null){
 
 		$this->elements = $elements;
 		$this->elements_len = count($elements);
 		$this->extendList = $extendList;
 		$this->condition = $condition;
-		if( $currentFileInfo ){
-			$this->currentFileInfo = $currentFileInfo;
-		}
 		$this->isReferenced = $isReferenced;
+		$this->reference = $reference;
 		if( !$condition ){
 			$this->evaldCondition = true;
 		}
@@ -58,7 +56,7 @@ class Less_Tree_Selector extends Less_Tree{
 	}
 
     public function createDerived( $elements, $extendList = null, $evaldCondition = null ){
-		$newSelector = new Less_Tree_Selector( $elements, ($extendList ? $extendList : $this->extendList), null, $this->index, $this->currentFileInfo, $this->isReferenced);
+		$newSelector = new Less_Tree_Selector( $elements, ($extendList ? $extendList : $this->extendList), null, $this->index, $this->reference, $this->isReferenced);
 		$newSelector->evaldCondition = $evaldCondition ? $evaldCondition : $this->evaldCondition;
 		return $newSelector;
 	}
@@ -145,7 +143,7 @@ class Less_Tree_Selector extends Less_Tree{
     public function genCSS( $output, $firstSelector = true ){
 
 		if( !$firstSelector && $this->elements[0]->combinator === "" ){
-			$output->add(' ', $this->currentFileInfo, $this->index);
+			$output->add(' ', Less_Environment::$currentFileInfo, $this->index);
 		}
 
 		foreach($this->elements as $element){
@@ -158,7 +156,7 @@ class Less_Tree_Selector extends Less_Tree{
 	}
 
     public function getIsReferenced(){
-		return !isset($this->currentFileInfo['reference']) || !$this->currentFileInfo['reference'] || $this->isReferenced;
+		return !isset($this->reference) || !$this->reference || $this->isReferenced;
 	}
 
     public function getIsOutput(){

--- a/lib/Less/Tree/Url.php
+++ b/lib/Less/Tree/Url.php
@@ -10,13 +10,13 @@ class Less_Tree_Url extends Less_Tree{
 
 	public $attrs;
 	public $value;
-	public $currentFileInfo;
+	public $uri_root;
 	public $isEvald;
 	public $type = 'Url';
 
-	public function __construct($value, $currentFileInfo = null, $isEvald = null){
+	public function __construct($value, $uri_root = null, $isEvald = null){
 		$this->value = $value;
-		$this->currentFileInfo = $currentFileInfo;
+		$this->uri_root = $uri_root;
 		$this->isEvald = $isEvald;
 	}
 
@@ -42,11 +42,11 @@ class Less_Tree_Url extends Less_Tree{
 		if( !$this->isEvald ){
 			// Add the base path if the URL is relative
 			if( Less_Parser::$options['relativeUrls']
-				&& $this->currentFileInfo
+				&& $this->uri_root
 				&& is_string($val->value)
 				&& Less_Environment::isPathRelative($val->value)
 			){
-				$rootpath = $this->currentFileInfo['uri_root'];
+				$rootpath = $this->uri_root;
 				if ( !$val->quote ){
 					$rootpath = preg_replace('/[\(\)\'"\s]/', '\\$1', $rootpath );
 				}
@@ -70,7 +70,7 @@ class Less_Tree_Url extends Less_Tree{
 			}
 		}
 
-		return new Less_Tree_URL($val, $this->currentFileInfo, true);
+		return new Less_Tree_URL($val, $this->uri_root, true);
 	}
 
 }

--- a/lib/Less/Tree/Variable.php
+++ b/lib/Less/Tree/Variable.php
@@ -10,30 +10,28 @@ class Less_Tree_Variable extends Less_Tree{
 
 	public $name;
 	public $index;
-	public $currentFileInfo;
 	public $evaluating = false;
 	public $type = 'Variable';
 
     /**
      * @param string $name
      */
-    public function __construct($name, $index = null, $currentFileInfo = null) {
+    public function __construct($name, $index = null) {
         $this->name = $name;
         $this->index = $index;
-		$this->currentFileInfo = $currentFileInfo;
     }
 
 	public function compile($env) {
 
 		if( $this->name[1] === '@' ){
-			$v = new Less_Tree_Variable(substr($this->name, 1), $this->index + 1, $this->currentFileInfo);
+			$v = new Less_Tree_Variable(substr($this->name, 1), $this->index + 1);
 			$name = '@' . $v->compile($env)->value;
 		}else{
 			$name = $this->name;
 		}
 
 		if ($this->evaluating) {
-			throw new Less_Exception_Compiler("Recursive variable definition for " . $name, null, $this->index, $this->currentFileInfo);
+			throw new Less_Exception_Compiler("Recursive variable definition for " . $name, null, $this->index, Less_Environment::$currentFileInfo);
 		}
 
 		$this->evaluating = true;
@@ -46,7 +44,7 @@ class Less_Tree_Variable extends Less_Tree{
 			}
 		}
 
-		throw new Less_Exception_Compiler("variable " . $name . " is undefined in file ".$this->currentFileInfo["filename"], null, $this->index, $this->currentFileInfo);
+		throw new Less_Exception_Compiler("variable " . $name . " is undefined in file ".Less_Environment::$currentFileInfo["filename"], null, $this->index, Less_Environment::$currentFileInfo);
 	}
 
 }

--- a/lib/Less/Visitor/processExtends.php
+++ b/lib/Less/Visitor/processExtends.php
@@ -402,8 +402,7 @@ class Less_Visitor_processExtends extends Less_Visitor{
 			$firstElement = new Less_Tree_Element(
 				$match['initialCombinator'],
 				$replacementSelector->elements[0]->value,
-				$replacementSelector->elements[0]->index,
-				$replacementSelector->elements[0]->currentFileInfo
+				$replacementSelector->elements[0]->index
 			);
 
 			if( $match['pathIndex'] > $currentSelectorPathIndex && $currentSelectorPathElementIndex > 0 ){

--- a/lib/Less/Visitor/toCSS.php
+++ b/lib/Less/Visitor/toCSS.php
@@ -57,7 +57,7 @@ class Less_Visitor_toCSS extends Less_VisitorReplacing{
 	}
 
 	public function visitDirective( $directiveNode ){
-		if( isset($directiveNode->currentFileInfo['reference']) && (!property_exists($directiveNode,'isReferenced') || !$directiveNode->isReferenced) ){
+		if(method_exists($directiveNode,'getIsReferenced') && !$directiveNode->getIsReferenced()) {
 			return array();
 		}
 		if( $directiveNode->name === '@charset' ){


### PR DESCRIPTION
A bottleneck in cache generation is the computation of `cache_string` due to the number of arguments needed to be exported. Examining cache I saw that `$currentFileInfo` is over and over repeated in the cache.

This pull request change the `$currentFileInfo` property from Less_Environment in a static property being used globally in all `Less/Tree/xxx` instead of duplicating the same property value everywhere.

The static property is poped and pulled before and after each inclusion, that was already done.

*`Tree/Comment`, `Tree/Directive`, `Tree/Mixin/Call` and `Tree/Selector` are keeping a copy of the reference flag of `$currentFileInfo`
* `Tree/Url` is keeping a copy of `uri_root`
* only `Tree/Import` is keeping a full copy of `$currentFileInfo`

Thus the cache footprint is divided by 8 on a real case life (of course depending of the `currentFileInfo` content) and the time consumption for generating `cache_string` property is also reduced