### PR TITLE
Performance improvements (+4% to speed in Magento2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: php
 
 php:
+  - 7.3
+  - 7.2
+  - 7.1
   - 7
   - 5.6
-  - 5.5
-  - 5.4
-  - 5.3
-  - hhvm
-  - nightly
-  
+
 sudo: false
 
 install:

--- a/lib/Less/Tree/Extend.php
+++ b/lib/Less/Tree/Extend.php
@@ -42,8 +42,10 @@ class Less_Tree_Extend extends Less_Tree{
 			break;
 		}
 
-		$this->object_id = $i++;
-		$this->parent_ids = array($this->object_id);
+		// string value is needed to make sure array_merge() processes keys as strings, not as numerics
+        $this->object_id = 'id_' . $i++;
+
+		$this->parent_ids = array($this->object_id => true);
 	}
 
     public function accept( $visitor ){

--- a/lib/Less/Tree/Selector.php
+++ b/lib/Less/Tree/Selector.php
@@ -22,6 +22,7 @@ class Less_Tree_Selector extends Less_Tree{
 	public $elements_len = 0;
 
 	public $_oelements;
+	public $_oelements_assoc;
 	public $_oelements_len;
 	public $cacheable = true;
 
@@ -83,6 +84,8 @@ class Less_Tree_Selector extends Less_Tree{
 	public function CacheElements(){
 
 		$this->_oelements = array();
+		$this->_oelements_assoc = array();
+
 		$css = '';
 
 		foreach($this->elements as $v){
@@ -108,6 +111,8 @@ class Less_Tree_Selector extends Less_Tree{
 				array_shift($this->_oelements);
 				$this->_oelements_len--;
 			}
+
+            $this->_oelements_assoc = array_fill_keys($this->_oelements, true);
 		}
 	}
 

--- a/lib/Less/Visitor/processExtends.php
+++ b/lib/Less/Visitor/processExtends.php
@@ -54,7 +54,7 @@ class Less_Visitor_processExtends extends Less_Visitor{
 				$targetExtend = $extendsListTarget[$targetExtendIndex];
 
 				// look for circular references
-				if( in_array($targetExtend->object_id, $extend->parent_ids,true) ){
+                if (isset($extend->parent_ids[$targetExtend->object_id])) {
 					continue;
 				}
 
@@ -269,7 +269,7 @@ class Less_Visitor_processExtends extends Less_Visitor{
 				return true;
 			}
 
-			if( in_array($first_el, $hackstackSelector->_oelements) ){
+            if (isset($hackstackSelector->_oelements_assoc[$first_el])) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Hi,

I've run xdebug profiler for Magento2 static content deploy and found huge amount of calls to in_array()
I've tried to optimize it and got ~4% performance improvement.

Pls review my changes.

Andrey